### PR TITLE
체스보드와 PawnⓂ️ 기능 및 테스트 코드 구현 #auto-merge

### DIFF
--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E894128328E37E2400DB15AE /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128228E37E2400DB15AE /* Color.swift */; };
+		E894128628E37E5300DB15AE /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128528E37E5300DB15AE /* Piece.swift */; };
+		E894128828E37E6C00DB15AE /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128728E37E6C00DB15AE /* Pawn.swift */; };
 		E8C67FE928E1DDD50033DE60 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */; };
 		E8C67FEB28E1DDD50033DE60 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FEA28E1DDD50033DE60 /* SceneDelegate.swift */; };
 		E8C67FED28E1DDD50033DE60 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FEC28E1DDD50033DE60 /* ViewController.swift */; };
@@ -35,6 +38,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E894128228E37E2400DB15AE /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
+		E894128528E37E5300DB15AE /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		E894128728E37E6C00DB15AE /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
 		E8C67FE528E1DDD50033DE60 /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E8C67FEA28E1DDD50033DE60 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -74,6 +80,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		E894127F28E37DFD00DB15AE /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				E894128228E37E2400DB15AE /* Color.swift */,
+				E894128728E37E6C00DB15AE /* Pawn.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		E894128428E37E4800DB15AE /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				E894128528E37E5300DB15AE /* Piece.swift */,
+			);
+			path = Protocol;
+			sourceTree = "<group>";
+		};
 		E8C67FDC28E1DDD40033DE60 = {
 			isa = PBXGroup;
 			children = (
@@ -97,6 +120,8 @@
 		E8C67FE728E1DDD50033DE60 /* ChessApp */ = {
 			isa = PBXGroup;
 			children = (
+				E894128428E37E4800DB15AE /* Protocol */,
+				E894127F28E37DFD00DB15AE /* Model */,
 				E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */,
 				E8C67FEA28E1DDD50033DE60 /* SceneDelegate.swift */,
 				E8C67FEC28E1DDD50033DE60 /* ViewController.swift */,
@@ -255,7 +280,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				E8C67FED28E1DDD50033DE60 /* ViewController.swift in Sources */,
+				E894128828E37E6C00DB15AE /* Pawn.swift in Sources */,
 				E8C67FE928E1DDD50033DE60 /* AppDelegate.swift in Sources */,
+				E894128628E37E5300DB15AE /* Piece.swift in Sources */,
+				E894128328E37E2400DB15AE /* Color.swift in Sources */,
 				E8C67FEB28E1DDD50033DE60 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -87,7 +87,6 @@
 		E894127F28E37DFD00DB15AE /* Model */ = {
 			isa = PBXGroup;
 			children = (
-				E894128028E37E1000DB15AE /* Board.swift */,
 				E894128228E37E2400DB15AE /* Color.swift */,
 				E894128728E37E6C00DB15AE /* Pawn.swift */,
 				E894128A28E38EF300DB15AE /* Position.swift */,
@@ -101,6 +100,14 @@
 				E894128528E37E5300DB15AE /* Piece.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		E894128928E38EE500DB15AE /* Module */ = {
+			isa = PBXGroup;
+			children = (
+				E894128028E37E1000DB15AE /* Board.swift */,
+			);
+			path = Module;
 			sourceTree = "<group>";
 		};
 		E8C67FDC28E1DDD40033DE60 = {
@@ -126,6 +133,7 @@
 		E8C67FE728E1DDD50033DE60 /* ChessApp */ = {
 			isa = PBXGroup;
 			children = (
+				E894128928E38EE500DB15AE /* Module */,
 				E894128428E37E4800DB15AE /* Protocol */,
 				E894127F28E37DFD00DB15AE /* Model */,
 				E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */,

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		E894128328E37E2400DB15AE /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128228E37E2400DB15AE /* Color.swift */; };
 		E894128628E37E5300DB15AE /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128528E37E5300DB15AE /* Piece.swift */; };
 		E894128828E37E6C00DB15AE /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128728E37E6C00DB15AE /* Pawn.swift */; };
+		E894128B28E38EF300DB15AE /* Position.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128A28E38EF300DB15AE /* Position.swift */; };
 		E8C67FE928E1DDD50033DE60 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */; };
 		E8C67FEB28E1DDD50033DE60 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FEA28E1DDD50033DE60 /* SceneDelegate.swift */; };
 		E8C67FED28E1DDD50033DE60 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8C67FEC28E1DDD50033DE60 /* ViewController.swift */; };
@@ -43,6 +44,7 @@
 		E894128228E37E2400DB15AE /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		E894128528E37E5300DB15AE /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		E894128728E37E6C00DB15AE /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		E894128A28E38EF300DB15AE /* Position.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Position.swift; sourceTree = "<group>"; };
 		E8C67FE528E1DDD50033DE60 /* ChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E8C67FE828E1DDD50033DE60 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E8C67FEA28E1DDD50033DE60 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -88,6 +90,7 @@
 				E894128028E37E1000DB15AE /* Board.swift */,
 				E894128228E37E2400DB15AE /* Color.swift */,
 				E894128728E37E6C00DB15AE /* Pawn.swift */,
+				E894128A28E38EF300DB15AE /* Position.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -288,6 +291,7 @@
 				E894128628E37E5300DB15AE /* Piece.swift in Sources */,
 				E894128128E37E1000DB15AE /* Board.swift in Sources */,
 				E894128328E37E2400DB15AE /* Color.swift in Sources */,
+				E894128B28E38EF300DB15AE /* Position.swift in Sources */,
 				E8C67FEB28E1DDD50033DE60 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ChessApp/ChessApp.xcodeproj/project.pbxproj
+++ b/ChessApp/ChessApp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		E894128128E37E1000DB15AE /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128028E37E1000DB15AE /* Board.swift */; };
 		E894128328E37E2400DB15AE /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128228E37E2400DB15AE /* Color.swift */; };
 		E894128628E37E5300DB15AE /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128528E37E5300DB15AE /* Piece.swift */; };
 		E894128828E37E6C00DB15AE /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = E894128728E37E6C00DB15AE /* Pawn.swift */; };
@@ -38,6 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		E894128028E37E1000DB15AE /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		E894128228E37E2400DB15AE /* Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		E894128528E37E5300DB15AE /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		E894128728E37E6C00DB15AE /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
@@ -83,6 +85,7 @@
 		E894127F28E37DFD00DB15AE /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				E894128028E37E1000DB15AE /* Board.swift */,
 				E894128228E37E2400DB15AE /* Color.swift */,
 				E894128728E37E6C00DB15AE /* Pawn.swift */,
 			);
@@ -283,6 +286,7 @@
 				E894128828E37E6C00DB15AE /* Pawn.swift in Sources */,
 				E8C67FE928E1DDD50033DE60 /* AppDelegate.swift in Sources */,
 				E894128628E37E5300DB15AE /* Piece.swift in Sources */,
+				E894128128E37E1000DB15AE /* Board.swift in Sources */,
 				E894128328E37E2400DB15AE /* Color.swift in Sources */,
 				E8C67FEB28E1DDD50033DE60 /* SceneDelegate.swift in Sources */,
 			);

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -1,0 +1,48 @@
+//
+//  Board.swift
+//  ChessApp
+//
+//  Created by MK-AM16-010 on 2022/09/28.
+//
+
+import Foundation
+
+final class Board {
+  
+  private let file: [String] = ["A", "B", "C", "D", "E", "F", "G", "H"]
+  private let rank: [String] = ["1", "2", "3", "4", "5", "6", "7", "8"]
+  
+  private var position: [[Piece?]] = [[]]
+  private var score: [Color: Int] = [.black: 0, .white: 0]
+  
+  init() {
+    self.reset()
+  }
+  
+  func reset() {
+    self.position = [
+      Array(repeating: nil, count: 8),
+      Array(repeating: Pawn(color: .black), count: 8),
+      Array(repeating: nil, count: 8),
+      Array(repeating: nil, count: 8),
+      Array(repeating: nil, count: 8),
+      Array(repeating: nil, count: 8),
+      Array(repeating: nil, count: 8),
+      Array(repeating: Pawn(color: .white), count: 8),
+      Array(repeating: nil, count: 8),
+    ]
+    
+    self.configureScore()
+  }
+  
+  func configureScore() {
+    let blackScore = self.position.flatMap { $0 }.filter { $0?.color == .black }
+      .reduce(into: 0) { $0 += ($1?.value ?? 0 )}
+    
+    let whiteScore = self.position.flatMap { $0 }.filter { $0?.color == .white }
+      .reduce(into: 0) { $0 += ($1?.value ?? 0 )}
+    
+    self.score = [.black: blackScore, .white: whiteScore]
+  }
+  
+}

--- a/ChessApp/ChessApp/Model/Board.swift
+++ b/ChessApp/ChessApp/Model/Board.swift
@@ -27,7 +27,6 @@ final class Board {
       Array(repeating: nil, count: 8),
       Array(repeating: nil, count: 8),
       Array(repeating: nil, count: 8),
-      Array(repeating: nil, count: 8),
       Array(repeating: Pawn(color: .white), count: 8),
       Array(repeating: nil, count: 8),
     ]
@@ -35,12 +34,33 @@ final class Board {
     self.configureScore()
   }
   
+  func display() -> String {
+    let fileLineString = " " + file.joined(separator: "")
+    
+    var rankLineString = ""
+    rank.enumerated().forEach {
+      let index = $0.offset
+      let rank = $0.element
+      
+      rankLineString += rank + self.position[index]
+        .reduce("") { $0 + ($1?.shape ?? ".")}
+      
+      rankLineString += "\n"
+    }
+    
+    return fileLineString + "\n" + rankLineString + fileLineString
+  }
+  
+  func displayScore() {
+    print(self.score)
+  }
+  
   func configureScore() {
     let blackScore = self.position.flatMap { $0 }.filter { $0?.color == .black }
-      .reduce(into: 0) { $0 += ($1?.value ?? 0 )}
+      .reduce(0) { $0 + ($1?.value ?? 0 )}
     
     let whiteScore = self.position.flatMap { $0 }.filter { $0?.color == .white }
-      .reduce(into: 0) { $0 += ($1?.value ?? 0 )}
+      .reduce(0) { $0 + ($1?.value ?? 0 )}
     
     self.score = [.black: blackScore, .white: whiteScore]
   }

--- a/ChessApp/ChessApp/Model/Color.swift
+++ b/ChessApp/ChessApp/Model/Color.swift
@@ -1,0 +1,13 @@
+//
+//  Color.swift
+//  ChessApp
+//
+//  Created by MK-AM16-010 on 2022/09/28.
+//
+
+import Foundation
+
+enum Color {
+  case black
+  case white
+}

--- a/ChessApp/ChessApp/Model/Pawn.swift
+++ b/ChessApp/ChessApp/Model/Pawn.swift
@@ -1,0 +1,24 @@
+//
+//  Pawn.swift
+//  ChessApp
+//
+//  Created by MK-AM16-010 on 2022/09/28.
+//
+
+import Foundation
+
+struct Pawn: Piece {
+  var shape: String
+  var color: Color
+  var value: Int
+  
+  init(color: Color) {
+    self.color = color
+    self.shape = color == .white ? "♙" : "♟"
+    self.value = 1
+  }
+  
+  func movablePositions(from: String) -> [String] {
+    []
+  }
+}

--- a/ChessApp/ChessApp/Model/Position.swift
+++ b/ChessApp/ChessApp/Model/Position.swift
@@ -1,0 +1,13 @@
+//
+//  Position.swift
+//  ChessApp
+//
+//  Created by MK-AM16-010 on 2022/09/28.
+//
+
+import Foundation
+
+struct Position {
+  let x: Int
+  let y: Int
+}

--- a/ChessApp/ChessApp/Module/Board.swift
+++ b/ChessApp/ChessApp/Module/Board.swift
@@ -43,16 +43,18 @@ final class Board {
       let rank = $0.element
       
       rankLineString += rank + self.position[index]
-        .reduce("") { $0 + ($1?.shape ?? ".")}
-      
+                               .reduce("") { $0 + ($1?.shape ?? ".")}
       rankLineString += "\n"
     }
     
     return fileLineString + "\n" + rankLineString + fileLineString
   }
   
-  func displayScore() {
-    print(self.score)
+  func displayScore() -> String {
+    let blackScore = self.score[.black] ?? 0
+    let whiteScore = self.score[.white] ?? 0
+    
+    return "흑: \(blackScore) 백: \(whiteScore)"
   }
   
   func configureScore() {
@@ -65,4 +67,37 @@ final class Board {
     self.score = [.black: blackScore, .white: whiteScore]
   }
   
+  func movePiece(from: String, to: String) -> Bool {
+    guard self.checkMoveValidate(position: from) && self.checkMoveValidate(position: to)
+    else {
+      return false
+    }
+    
+    return true
+  }
+  
+  private func checkMoveValidate(position: String) -> Bool {
+    guard position.count == 2 else { return false }
+    
+    let split = position.map { String($0) }
+    
+    let file = split.first ?? ""
+    let rank = split.last ?? ""
+    
+    return self.file.contains(file) && self.rank.contains(rank)
+  }
+  
+  func position(from position: String) -> Position? {
+    let split = position.map { String($0) }
+    
+    guard let file = split.first,
+          let rank = split.last,
+          let fileIndex = self.file.firstIndex(of: file),
+          let rankIndex = self.rank.firstIndex(of: rank)
+    else {
+      return nil
+    }
+    
+    return Position(x: rankIndex, y: fileIndex)
+  }
 }

--- a/ChessApp/ChessApp/Protocol/Piece.swift
+++ b/ChessApp/ChessApp/Protocol/Piece.swift
@@ -1,0 +1,16 @@
+//
+//  Piece.swift
+//  ChessApp
+//
+//  Created by MK-AM16-010 on 2022/09/28.
+//
+
+import Foundation
+
+protocol Piece {
+  var shape: String { get set }
+  var color: Color { get set }
+  var value: Int { get set }
+  
+  func movablePositions(from: String) -> [String]
+}

--- a/ChessApp/ChessAppTests/ChessAppTests.swift
+++ b/ChessApp/ChessAppTests/ChessAppTests.swift
@@ -35,4 +35,12 @@ final class ChessAppTests: XCTestCase {
     
     XCTAssertEqual(expectBoard, displayBoard)
   }
+  
+  func testInitBoardDisplayScore() {
+    let expectBoardScore = "흑: 8 백: 8"
+    
+    let displayBoardScore = self.board.displayScore()
+    
+    XCTAssertEqual(expectBoardScore, displayBoardScore)
+  }
 }

--- a/ChessApp/ChessAppTests/ChessAppTests.swift
+++ b/ChessApp/ChessAppTests/ChessAppTests.swift
@@ -9,5 +9,30 @@ import XCTest
 @testable import ChessApp
 
 final class ChessAppTests: XCTestCase {
-
+  var board: Board!
+  
+  override func setUp() {
+    super.setUp()
+    
+    self.board = Board()
+  }
+  
+  func testBoardDisplay() {
+    let expectBoard = """
+                       ABCDEFGH
+                      1........
+                      2♟♟♟♟♟♟♟♟
+                      3........
+                      4........
+                      5........
+                      6........
+                      7♙♙♙♙♙♙♙♙
+                      8........
+                       ABCDEFGH
+                      """
+    
+    let displayBoard = self.board.display()
+    
+    XCTAssertEqual(expectBoard, displayBoard)
+  }
 }

--- a/ChessApp/ChessAppTests/ChessAppTests.swift
+++ b/ChessApp/ChessAppTests/ChessAppTests.swift
@@ -43,4 +43,12 @@ final class ChessAppTests: XCTestCase {
     
     XCTAssertEqual(expectBoardScore, displayBoardScore)
   }
+  
+  func testChecValidationkMoviePosition() {
+    let expectResult = false
+    
+    let isMovable = self.board.movePiece(from: "AA", to: "A1")
+    
+    XCTAssertEqual(expectResult, isMovable)
+  }
 }


### PR DESCRIPTION
## 구현사항 
- `Piece`: 체스말 타입
  - protocol이고 체스말이 되기 위한 조건들을 포함하고 있습니다.
  - 모양, 색상, 점수가 선언되어 있습니다.

- `Board`: 체스판
  - row, column 정보를 가지고 있습니다.
  - 현재 체스말에 대한 위치 정보를 가지고 있습니다.
  - 현재 점수를 가지고 있습니다.

---
## 설계하면서 고민이 되었던 문제
1. Piece, Pawn
  만들고 나니 고민이 되었는데요,
  체스말에 고유로 설정된 데이터들을 외부에서 주입받는게 아니라면 체스말의 점수나 체스말이 최대 몇칸을 움직일 수 있는지와 같은 상태값도 하나 
  의 타입에 묶이는게 어떨까요?
  아래처럼 `Piece` 프로토콜을 사용하지 않고 `PieceType`을 만들고 내부에 `value`(체스말 점수)를 두게 되고,
  체스말의 모양인 `shape`의 경우는 init시점에 `Color`와 `PieceType`을 보고 결정하게 되도록 구현하는게 좋을 것 같다고도 생각이 듭니다.
  
  추가로 이렇게 되면 초기 생성 위치..등 가지고 있는 프로퍼티가 많아질 것 같아 고민이 될 것 같습니다.
```swift
enum PieceType {
    case pawn

    var value: Int {
        switch self {
        case .pawn:
            return 1
        }
    }

   var maxMovePosition: ...
}
```
---
## 테스트시 고민이 되었던 점

---
## 미구현된 부분들에 대해
1. 설계초기단계에 `계층적으로 구분할 지, 타입으로 구분할 지, 데이터 흐름으로 구분할 지 `에 대한 고민을 깊게 하지 않은 채로 코드를 작성했었는데요.
  제가 생각하기에는 지금은 데이터 흐름으로 구분을 하고 있는 것 같은데, 이후에는 각 역할에 맞는 타입이나 계층을 나누어야 할 것 같습니다.

2. 현재 입력된 위치에 대해서 체스말을 옮기는 로직을 구현하지 못했습니다.
  지금까지 구현된 것은 입력된 위치에 대해서 Position 객체로 변환하는 과정까지 진행했는데요.
  추후에는 아래와 같은 순서로 추가해 나갈 예정입니다.
  - 각 position을 받아 위치하는 `Piece`를 가져옴.
  - 해당 해당 `Piece`의 movablePositions(from:) 메서드에서 이동 가능한 위치를 가져옴.
  - 이동 가능한 위치의 유효성은 Board가 판단 (같은 색상, 다른 색상에 따라 달라짐)
  - 점수 업데이트
