### PR TITLE
[STEP 1] 체스보드와 PawnⓂ️ #auto-merge

### DIFF
--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAA28E43F240051D8CB /* PawnTests.swift */; };
 		AA53ACAD28E457610051D8CB /* Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAC28E457610051D8CB /* Occupiable.swift */; };
 		AA53ACB228E473430051D8CB /* BoardTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB128E473430051D8CB /* BoardTesting.swift */; };
+		AA53ACB528E491430051D8CB /* CommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB428E491430051D8CB /* CommandParser.swift */; };
+		AA53ACB728E491540051D8CB /* CommandReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB628E491540051D8CB /* CommandReader.swift */; };
+		AA53ACB928E497B10051D8CB /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB828E497B10051D8CB /* String+Extensions.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -52,6 +55,9 @@
 		AA53ACAA28E43F240051D8CB /* PawnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PawnTests.swift; sourceTree = "<group>"; };
 		AA53ACAC28E457610051D8CB /* Occupiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Occupiable.swift; sourceTree = "<group>"; };
 		AA53ACB128E473430051D8CB /* BoardTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTesting.swift; sourceTree = "<group>"; };
+		AA53ACB428E491430051D8CB /* CommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParser.swift; sourceTree = "<group>"; };
+		AA53ACB628E491540051D8CB /* CommandReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandReader.swift; sourceTree = "<group>"; };
+		AA53ACB828E497B10051D8CB /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -95,6 +101,7 @@
 		AA53AC9428E414140051D8CB /* Board */ = {
 			isa = PBXGroup;
 			children = (
+				AA53ACB328E491360051D8CB /* Component */,
 				AA53AC9728E41A870051D8CB /* Model */,
 				AA53AC9528E41A840051D8CB /* Board.swift */,
 			);
@@ -125,6 +132,7 @@
 			children = (
 				AA53ACA528E43E720051D8CB /* Int+Extensions.swift */,
 				AA53ACAC28E457610051D8CB /* Occupiable.swift */,
+				AA53ACB828E497B10051D8CB /* String+Extensions.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -135,6 +143,15 @@
 				AA53ACAA28E43F240051D8CB /* PawnTests.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		AA53ACB328E491360051D8CB /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				AA53ACB428E491430051D8CB /* CommandParser.swift */,
+				AA53ACB628E491540051D8CB /* CommandReader.swift */,
+			);
+			path = Component;
 			sourceTree = "<group>";
 		};
 		AABA53A828E1D31A00006508 = {
@@ -384,10 +401,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */,
+				AA53ACB928E497B10051D8CB /* String+Extensions.swift in Sources */,
 				AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */,
 				AA53ACAD28E457610051D8CB /* Occupiable.swift in Sources */,
 				AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */,
+				AA53ACB528E491430051D8CB /* CommandParser.swift in Sources */,
 				AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */,
+				AA53ACB728E491540051D8CB /* CommandReader.swift in Sources */,
 				AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */,
 				AA53AC9628E41A840051D8CB /* Board.swift in Sources */,
 				AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */,

--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		AA53ACB528E491430051D8CB /* CommandParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB428E491430051D8CB /* CommandParser.swift */; };
 		AA53ACB728E491540051D8CB /* CommandReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB628E491540051D8CB /* CommandReader.swift */; };
 		AA53ACB928E497B10051D8CB /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB828E497B10051D8CB /* String+Extensions.swift */; };
+		AA53ACBD28E4A21F0051D8CB /* CommandParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACBC28E4A21F0051D8CB /* CommandParserTests.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -58,6 +59,7 @@
 		AA53ACB428E491430051D8CB /* CommandParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParser.swift; sourceTree = "<group>"; };
 		AA53ACB628E491540051D8CB /* CommandReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandReader.swift; sourceTree = "<group>"; };
 		AA53ACB828E497B10051D8CB /* String+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
+		AA53ACBC28E4A21F0051D8CB /* CommandParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandParserTests.swift; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -120,6 +122,7 @@
 		AA53AC9D28E43D240051D8CB /* Board */ = {
 			isa = PBXGroup;
 			children = (
+				AA53ACBB28E4A2030051D8CB /* Component */,
 				AA53ACA728E43F0A0051D8CB /* Model */,
 				AA53ACA028E43D3E0051D8CB /* BoardTests.swift */,
 				AA53ACB128E473430051D8CB /* BoardTesting.swift */,
@@ -150,6 +153,14 @@
 			children = (
 				AA53ACB428E491430051D8CB /* CommandParser.swift */,
 				AA53ACB628E491540051D8CB /* CommandReader.swift */,
+			);
+			path = Component;
+			sourceTree = "<group>";
+		};
+		AA53ACBB28E4A2030051D8CB /* Component */ = {
+			isa = PBXGroup;
+			children = (
+				AA53ACBC28E4A21F0051D8CB /* CommandParserTests.swift */,
 			);
 			path = Component;
 			sourceTree = "<group>";
@@ -422,6 +433,7 @@
 				AA53ACA128E43D3E0051D8CB /* BoardTests.swift in Sources */,
 				AABA53CC28E1D31C00006508 /* SwiftChessTests.swift in Sources */,
 				AA53ACB228E473430051D8CB /* BoardTesting.swift in Sources */,
+				AA53ACBD28E4A21F0051D8CB /* CommandParserTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACA528E43E720051D8CB /* Int+Extensions.swift */; };
 		AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAA28E43F240051D8CB /* PawnTests.swift */; };
 		AA53ACAD28E457610051D8CB /* Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAC28E457610051D8CB /* Occupiable.swift */; };
+		AA53ACB228E473430051D8CB /* BoardTesting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACB128E473430051D8CB /* BoardTesting.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -50,6 +51,7 @@
 		AA53ACA528E43E720051D8CB /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		AA53ACAA28E43F240051D8CB /* PawnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PawnTests.swift; sourceTree = "<group>"; };
 		AA53ACAC28E457610051D8CB /* Occupiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Occupiable.swift; sourceTree = "<group>"; };
+		AA53ACB128E473430051D8CB /* BoardTesting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTesting.swift; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -113,6 +115,7 @@
 			children = (
 				AA53ACA728E43F0A0051D8CB /* Model */,
 				AA53ACA028E43D3E0051D8CB /* BoardTests.swift */,
+				AA53ACB128E473430051D8CB /* BoardTesting.swift */,
 			);
 			path = Board;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */,
 				AA53ACA128E43D3E0051D8CB /* BoardTests.swift in Sources */,
 				AABA53CC28E1D31C00006508 /* SwiftChessTests.swift in Sources */,
+				AA53ACB228E473430051D8CB /* BoardTesting.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -10,6 +10,9 @@
 		AA53AC9628E41A840051D8CB /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9528E41A840051D8CB /* Board.swift */; };
 		AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9828E41A8D0051D8CB /* Piece.swift */; };
 		AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9A28E41AB70051D8CB /* Pawn.swift */; };
+		AA53ACA128E43D3E0051D8CB /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACA028E43D3E0051D8CB /* BoardTests.swift */; };
+		AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACA528E43E720051D8CB /* Int+Extensions.swift */; };
+		AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAA28E43F240051D8CB /* PawnTests.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -42,6 +45,9 @@
 		AA53AC9528E41A840051D8CB /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
 		AA53AC9828E41A8D0051D8CB /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		AA53AC9A28E41AB70051D8CB /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
+		AA53ACA028E43D3E0051D8CB /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
+		AA53ACA528E43E720051D8CB /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
+		AA53ACAA28E43F240051D8CB /* PawnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PawnTests.swift; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +106,31 @@
 			path = Model;
 			sourceTree = "<group>";
 		};
+		AA53AC9D28E43D240051D8CB /* Board */ = {
+			isa = PBXGroup;
+			children = (
+				AA53ACA728E43F0A0051D8CB /* Model */,
+				AA53ACA028E43D3E0051D8CB /* BoardTests.swift */,
+			);
+			path = Board;
+			sourceTree = "<group>";
+		};
+		AA53ACA228E43E580051D8CB /* Common */ = {
+			isa = PBXGroup;
+			children = (
+				AA53ACA528E43E720051D8CB /* Int+Extensions.swift */,
+			);
+			path = Common;
+			sourceTree = "<group>";
+		};
+		AA53ACA728E43F0A0051D8CB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AA53ACAA28E43F240051D8CB /* PawnTests.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		AABA53A828E1D31A00006508 = {
 			isa = PBXGroup;
 			children = (
@@ -133,6 +164,7 @@
 		AABA53CA28E1D31C00006508 /* SwiftChessTests */ = {
 			isa = PBXGroup;
 			children = (
+				AA53AC9D28E43D240051D8CB /* Board */,
 				AABA53CB28E1D31C00006508 /* SwiftChessTests.swift */,
 			);
 			path = SwiftChessTests;
@@ -169,6 +201,7 @@
 			children = (
 				AABA53E428E1D3FA00006508 /* Application */,
 				AA53AC9428E414140051D8CB /* Board */,
+				AA53ACA228E43E580051D8CB /* Common */,
 				AABA53E528E1D4C900006508 /* Home */,
 			);
 			path = Sources;
@@ -348,6 +381,7 @@
 				AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */,
 				AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */,
 				AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */,
+				AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */,
 				AA53AC9628E41A840051D8CB /* Board.swift in Sources */,
 				AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */,
 			);
@@ -357,6 +391,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */,
+				AA53ACA128E43D3E0051D8CB /* BoardTests.swift in Sources */,
 				AABA53CC28E1D31C00006508 /* SwiftChessTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AA53AC9628E41A840051D8CB /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9528E41A840051D8CB /* Board.swift */; };
+		AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9828E41A8D0051D8CB /* Piece.swift */; };
+		AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53AC9A28E41AB70051D8CB /* Pawn.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -36,6 +39,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AA53AC9528E41A840051D8CB /* Board.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Board.swift; sourceTree = "<group>"; };
+		AA53AC9828E41A8D0051D8CB /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
+		AA53AC9A28E41AB70051D8CB /* Pawn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Pawn.swift; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -76,6 +82,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AA53AC9428E414140051D8CB /* Board */ = {
+			isa = PBXGroup;
+			children = (
+				AA53AC9728E41A870051D8CB /* Model */,
+				AA53AC9528E41A840051D8CB /* Board.swift */,
+			);
+			path = Board;
+			sourceTree = "<group>";
+		};
+		AA53AC9728E41A870051D8CB /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				AA53AC9A28E41AB70051D8CB /* Pawn.swift */,
+				AA53AC9828E41A8D0051D8CB /* Piece.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		AABA53A828E1D31A00006508 = {
 			isa = PBXGroup;
 			children = (
@@ -144,6 +168,7 @@
 			isa = PBXGroup;
 			children = (
 				AABA53E428E1D3FA00006508 /* Application */,
+				AA53AC9428E414140051D8CB /* Board */,
 				AABA53E528E1D4C900006508 /* Home */,
 			);
 			path = Sources;
@@ -320,7 +345,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */,
+				AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */,
 				AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */,
+				AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */,
+				AA53AC9628E41A840051D8CB /* Board.swift in Sources */,
 				AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
+++ b/SwiftChess/SwiftChess.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		AA53ACA128E43D3E0051D8CB /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACA028E43D3E0051D8CB /* BoardTests.swift */; };
 		AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACA528E43E720051D8CB /* Int+Extensions.swift */; };
 		AA53ACAB28E43F240051D8CB /* PawnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAA28E43F240051D8CB /* PawnTests.swift */; };
+		AA53ACAD28E457610051D8CB /* Occupiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA53ACAC28E457610051D8CB /* Occupiable.swift */; };
 		AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B428E1D31B00006508 /* AppDelegate.swift */; };
 		AABA53B728E1D31B00006508 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B628E1D31B00006508 /* SceneDelegate.swift */; };
 		AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABA53B828E1D31B00006508 /* HomeViewController.swift */; };
@@ -48,6 +49,7 @@
 		AA53ACA028E43D3E0051D8CB /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
 		AA53ACA528E43E720051D8CB /* Int+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Int+Extensions.swift"; sourceTree = "<group>"; };
 		AA53ACAA28E43F240051D8CB /* PawnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PawnTests.swift; sourceTree = "<group>"; };
+		AA53ACAC28E457610051D8CB /* Occupiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Occupiable.swift; sourceTree = "<group>"; };
 		AABA53B128E1D31B00006508 /* SwiftChess.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChess.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AABA53B428E1D31B00006508 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AABA53B628E1D31B00006508 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -119,6 +121,7 @@
 			isa = PBXGroup;
 			children = (
 				AA53ACA528E43E720051D8CB /* Int+Extensions.swift */,
+				AA53ACAC28E457610051D8CB /* Occupiable.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -379,6 +382,7 @@
 			files = (
 				AABA53B928E1D31B00006508 /* HomeViewController.swift in Sources */,
 				AA53AC9B28E41AB70051D8CB /* Pawn.swift in Sources */,
+				AA53ACAD28E457610051D8CB /* Occupiable.swift in Sources */,
 				AABA53B528E1D31B00006508 /* AppDelegate.swift in Sources */,
 				AA53AC9928E41A8D0051D8CB /* Piece.swift in Sources */,
 				AA53ACA628E43E720051D8CB /* Int+Extensions.swift in Sources */,

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -98,6 +98,26 @@ final class Board {
         }
     }
 
+    // MARK: - 사용자 입력
+
+    func readCommand() -> String? {
+        do {
+            return try CommandReader.read()
+        } catch {
+            // TODO: Log error
+            return nil
+        }
+    }
+
+    func parseCommand(_ command: String) -> MoveCommand? {
+        do {
+            return try CommandParser.parse(command)
+        } catch {
+            // TODO: Log error
+            return nil
+        }
+    }
+
     // MARK: - 체스말 이동
 
     /// 체스말을 시작점에서 목적지로 이동시킨다.
@@ -240,6 +260,10 @@ extension Board {
         static let size = Size(rank: 8, file: 8)
         /// 진영별 얻을 수 있는 총 점수
         static let totalAvailablePoints = Pawn.point * Pawn.maxCount
+        static let minimumRank = 1
+        static let maximumRank = 8
+        static let minimumFile: String = "A"
+        static let maximumFile: String = "H"
     }
 
     /// 체스판 내 위치를 나타내는 타입.

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -7,22 +7,87 @@
 
 final class Board {
 
-    private var status: [[Piece?]] = []
+    private(set) var status: [[Piece?]] = []
+
+    /// 주어진 상태로 체스판을 초기화한다.
+    init(
+        status: [[Piece?]]
+    ) {
+        self.status = status
+    }
+
+    /// 지정된 방식으로 체스판을 초기화한다.
+    init() {
+        setInitialState()
+    }
+
+    // MARK: - Board 초기화 시 status 구성
+
+    /// 지정된 구성으로 ``Board``의 ``Board/status``를 초기화한다.
+    private func setInitialState() {
+        setEmptyState()
+        setPawns()
+    }
+
+    /// ``Board/status``를 빈 상태로 설정한다. 크기는 ``Board/Configuration/size``를 따른다.
+    private func setEmptyState() {
+        let emptyRank: [Piece?] = Array(
+            repeating: nil,
+            count: Self.Configuration.size.file
+        )
+        status = Array(
+            repeating: emptyRank,
+            count: Self.Configuration.size.rank
+        )
+    }
+
+    /// 색상별 ``Pawn``을 지정된 위치에 둔다. 색상별 ``Pawn``의 위치는 ``Pawn/initialRankIndex``를 참고한다.
+    private func setPawns() {
+        for pieceColor in PieceColor.allCases {
+            setPawns(for: pieceColor)
+        }
+    }
+
+    /// 지정된 색상의 ``Pawn``을 위치에 둔다. 색상별 ``Pawn``의 위치는 ``Pawn/initialRankIndex``를 참고한다.
+    private func setPawns(for pieceColor: PieceColor) {
+        switch pieceColor {
+        case .black:
+            let blackPawn = Pawn(color: .black)
+            let blackPawnRank = Array(
+                repeating: blackPawn,
+                count: Self.Configuration.size.file
+            )
+            status[blackPawn.initialRankIndex] = blackPawnRank
+
+        case .white:
+            let whitePawn = Pawn(color: .white)
+            let whitePawnRank = Array(
+                repeating: whitePawn,
+                count: Self.Configuration.size.file
+            )
+            status[whitePawn.initialRankIndex] = whitePawnRank
+        }
+    }
 }
 
 extension Board {
 
     enum Configuration {
+        /// 체스판의 크기
         static let size = Board.Size(rank: 8, file: 8)
     }
 
     struct Size {
+        /// 행(Row)
         let rank: Int
+        /// 열(Column)
         let file: Int
     }
 
     struct Location {
+        /// 행(Row)
         var rank: Int
+        /// 열(Column)
         var file: Int
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -24,6 +24,7 @@ enum BoardError: Error, Equatable {
     case identicalColoredPieceAlreadyExists(endPoint: Board.Location)
 }
 
+/// 체스판 타입.
 final class Board {
 
     /// 체스판의 상태. 체스말이 놓여진 상태를 확인할 수 있다. 빈 위치는 `nil`로 표현한다.

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -5,6 +5,10 @@
 //  Created by Geonhee on 2022/09/28.
 //
 
+enum BoardError: Error {
+    case invalidRank
+}
+
 final class Board {
 
     private(set) var status: [[Piece?]] = []

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -213,6 +213,21 @@ final class Board {
             }
         }
     }
+
+    // MARK: - 체스판 표현
+
+    /// 현재 체스판 상황을 콘솔에 출력한다.
+    @discardableResult
+    func display() -> String {
+        let graphicalRepresentation = status.map { rank in
+            return rank
+                .map { $0?.asSymbol ?? PieceSymbol.empty.rawValue }
+                .joined()
+        }
+            .joined(separator: "\n")
+        print(graphicalRepresentation)
+        return graphicalRepresentation
+    }
 }
 
 extension Board {

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -212,6 +212,7 @@ final class Board {
 
 extension Board {
 
+    /// 체스판의 환경변수를 정의한 타입.
     enum Configuration {
         typealias Size = (rank: Int, file: Int)
 
@@ -221,6 +222,7 @@ extension Board {
         static let totalAvailablePoints = Pawn.point * Pawn.maxCount
     }
 
+    /// 체스판 내 위치를 나타내는 타입.
     struct Location: Equatable {
         /// 행(Row)
         var rank: Int
@@ -239,6 +241,7 @@ extension Board.Location {
         return Self(rank: lhs.rank - rhs.rank, file: lhs.file - rhs.file)
     }
 
+    /// 해당 위치가 체스판 안에 존재하는지 여부를 반환한다.
     var isValid: Bool {
         return (1...Board.Configuration.size.rank).contains(self.rank) &&
         (1...Board.Configuration.size.file).contains(self.file)

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -1,0 +1,28 @@
+//
+//  Board.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+final class Board {
+
+    private var status: [[Piece?]] = []
+}
+
+extension Board {
+
+    enum Configuration {
+        static let size = Board.Size(rank: 8, file: 8)
+    }
+
+    struct Size {
+        let rank: Int
+        let file: Int
+    }
+
+    struct Location {
+        var rank: Int
+        var file: Int
+    }
+}

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -213,17 +213,12 @@ final class Board {
 extension Board {
 
     enum Configuration {
+        typealias Size = (rank: Int, file: Int)
+
         /// 체스판의 크기
-        static let size = Board.Size(rank: 8, file: 8)
+        static let size = Size(rank: 8, file: 8)
         /// 진영별 얻을 수 있는 총 점수
         static let totalAvailablePoints = Pawn.point * Pawn.maxCount
-    }
-
-    struct Size {
-        /// 행(Row)
-        let rank: Int
-        /// 열(Column)
-        let file: Int
     }
 
     struct Location: Equatable {

--- a/SwiftChess/SwiftChess/Sources/Board/Board.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Board.swift
@@ -57,7 +57,7 @@ final class Board {
                 repeating: blackPawn,
                 count: Self.Configuration.size.file
             )
-            status[blackPawn.initialRankIndex] = blackPawnRank
+            status[blackPawn.initialRank.asIndex] = blackPawnRank
 
         case .white:
             let whitePawn = Pawn(color: .white)
@@ -65,7 +65,7 @@ final class Board {
                 repeating: whitePawn,
                 count: Self.Configuration.size.file
             )
-            status[whitePawn.initialRankIndex] = whitePawnRank
+            status[whitePawn.initialRank.asIndex] = whitePawnRank
         }
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
@@ -1,0 +1,112 @@
+//
+//  CommandParser.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+struct MoveCommand {
+    let startPoint: Board.Location
+    let endPoint: Board.Location
+}
+
+enum CommandParserError: Error {
+    case invalidCommand
+    case validationFailed
+    case locationStringsNotExist
+    case fileOrRankCharacterNotExists
+}
+
+struct CommandParser {
+
+    static func parse(_ command: String) throws -> MoveCommand {
+        let locations = command.split(separator: "->")
+
+        guard validate(locations) else {
+            throw CommandParserError.validationFailed
+        }
+
+        guard let startPoint = locations.first,
+              let endPoint = locations.last else {
+            throw CommandParserError.locationStringsNotExist
+        }
+
+        let startPointLocation = try makeLocation(with: startPoint)
+        let endPointLocation = try makeLocation(with: endPoint)
+        return MoveCommand(
+            startPoint: startPointLocation,
+            endPoint: endPointLocation
+        )
+    }
+
+    private static func validate(_ locationStrings: [String.SubSequence]) -> Bool {
+        guard locationStrings.count == 2 else {
+            // TODO: 로그 CommandParserError.invalidCommand
+            return false
+        }
+
+        guard let startPoint = locationStrings.first else {
+            return false
+        }
+
+        guard let endPoint = locationStrings.last else {
+            return false
+        }
+
+        guard validateEach(startPoint) else {
+            return false
+        }
+
+        guard validateEach(endPoint) else {
+            return false
+        }
+
+        return true
+    }
+
+    private static func validateEach(_ locationString: Substring) -> Bool {
+        guard locationString.count == 2 else {
+            return false
+        }
+
+        guard let fileCandidate = locationString.first else {
+            return false
+        }
+
+        guard let rankCandidate = locationString.last else {
+            return false
+        }
+
+        let file = String(fileCandidate)
+        guard let rank = Int(String(rankCandidate)) else {
+            return false
+        }
+
+        let minimumFileAsciiValue = Board.Configuration.minimumFile.asAsciiValue
+        let maximumFileAsciiValue = Board.Configuration.maximumFile.asAsciiValue
+
+        guard (minimumFileAsciiValue...maximumFileAsciiValue).contains(file.asAsciiValue) else {
+            return false
+        }
+
+        let minimumRank = Board.Configuration.minimumRank
+        let maximumRank = Board.Configuration.maximumRank
+
+        guard (minimumRank...maximumRank).contains(rank) else {
+            return false
+        }
+        return true
+    }
+
+    private static func makeLocation(with substring: Substring) throws -> Board.Location {
+        guard let file = substring.first,
+              let rank = substring.last else {
+            throw CommandParserError.fileOrRankCharacterNotExists
+        }
+
+        return Board.Location(
+            rank: String(rank).asRankIndex,
+            file: String(file).asFileIndex
+        )
+    }
+}

--- a/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
@@ -22,7 +22,7 @@ enum CommandParserError: Error {
 }
 
 /// 사용자 입력을 해석하는 타입.
-struct CommandParser {
+enum CommandParser {
 
     /// 문자열 형식의 사용자 명령문을 해석하여 ``MoveCommand`` 인스턴스로 반환한다.
     static func parse(_ command: String) throws -> MoveCommand {

--- a/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Component/CommandParser.swift
@@ -11,14 +11,20 @@ struct MoveCommand {
 }
 
 enum CommandParserError: Error {
+    /// 유효하지 않은 명령
     case invalidCommand
+    /// 검증 실패(형식에 맞지않음, 유효하지 않은 출발점/목적지 등)
     case validationFailed
+    /// 검증을 마친 문자열이 사라짐(발생하지 않음)
     case locationStringsNotExist
+    /// 검증을 마친 캐릭터가 사라짐(발생하지 않음)
     case fileOrRankCharacterNotExists
 }
 
+/// 사용자 입력을 해석하는 타입.
 struct CommandParser {
 
+    /// 문자열 형식의 사용자 명령문을 해석하여 ``MoveCommand`` 인스턴스로 반환한다.
     static func parse(_ command: String) throws -> MoveCommand {
         let locations = command.split(separator: "->")
 
@@ -39,6 +45,7 @@ struct CommandParser {
         )
     }
 
+    /// 구분자 `->`를 기준으로 분리된 문자열들을 검증한다. 예) ["A1", "A2"]
     private static func validate(_ locationStrings: [String.SubSequence]) -> Bool {
         guard locationStrings.count == 2 else {
             // TODO: 로그 CommandParserError.invalidCommand
@@ -64,6 +71,7 @@ struct CommandParser {
         return true
     }
 
+    /// 시작점 또는 목적지와 같이 하나의 문자열을 검증한다. 예) "A1"
     private static func validateEach(_ locationString: Substring) -> Bool {
         guard locationString.count == 2 else {
             return false
@@ -98,6 +106,8 @@ struct CommandParser {
         return true
     }
 
+    /// `Substring` 타입의 문자열을 ``Board/Location`` 인스턴스로 바꾸어 반환한다.
+    /// ``CommandParser/validate(_:)``를 통해 검증된 결과만 전달해주어야 한다.
     private static func makeLocation(with substring: Substring) throws -> Board.Location {
         guard let file = substring.first,
               let rank = substring.last else {

--- a/SwiftChess/SwiftChess/Sources/Board/Component/CommandReader.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Component/CommandReader.swift
@@ -9,8 +9,10 @@ enum CommandReaderError: Error {
     case inputNotExists
 }
 
+/// 사용자 입력을 받는 타입.
 enum CommandReader {
 
+    /// 사용자가 콘솔에 입력한 명령을 읽어 반환한다.
     static func read() throws -> String {
         guard let command = readLine() else {
             throw CommandReaderError.inputNotExists

--- a/SwiftChess/SwiftChess/Sources/Board/Component/CommandReader.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Component/CommandReader.swift
@@ -1,0 +1,20 @@
+//
+//  CommandReader.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+enum CommandReaderError: Error {
+    case inputNotExists
+}
+
+enum CommandReader {
+
+    static func read() throws -> String {
+        guard let command = readLine() else {
+            throw CommandReaderError.inputNotExists
+        }
+        return command
+    }
+}

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -30,17 +30,15 @@ extension Pawn {
         from location: Board.Location
     ) -> [Board.Location] {
         guard let moveRule = Self.moveRules.first else { return [] }
-        var destination: Board.Location
 
         switch color {
         case .black:
-            destination = location + moveRule
+            return [location + moveRule]
+                .filter(\.isValid)
 
         case .white:
-            destination = location - moveRule
+            return [location - moveRule]
+                .filter(\.isValid)
         }
-
-        guard destination.isValid else { return [] }
-        return [destination]
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -5,6 +5,7 @@
 //  Created by Geonhee on 2022/09/28.
 //
 
+/// 체스말 폰.
 struct Pawn: Piece {
     static let moveRules: Set<MoveRule> = [MoveRule(rank: 1, file: 0)]
     static let maxCount: Int = 8

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -1,0 +1,10 @@
+//
+//  Pawn.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+struct Pawn: Piece {
+
+}

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -6,5 +6,17 @@
 //
 
 struct Pawn: Piece {
+    static let maxCount: Int = 8
 
+    let color: PieceColor
+
+    var initialRankIndex: Int {
+        switch color {
+        case .black:
+            return 1
+
+        case .white:
+            return 6
+        }
+    }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -6,7 +6,9 @@
 //
 
 struct Pawn: Piece {
+    static let moveRules: Set<MoveRule> = [MoveRule(rank: 0, file: 1)]
     static let maxCount: Int = 8
+    static let point: Int = 1
 
     let color: PieceColor
 
@@ -17,6 +19,23 @@ struct Pawn: Piece {
 
         case .white:
             return 7
+        }
+    }
+}
+
+extension Pawn {
+
+    func movableLocations(
+        from location: Board.Location
+    ) -> [Board.Location] {
+        guard let moveRule = Self.moveRules.first else { return [] }
+
+        switch color {
+        case .black:
+            return [location + moveRule]
+
+        case .white:
+            return [location - moveRule]
         }
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -6,13 +6,13 @@
 //
 
 struct Pawn: Piece {
-    static let moveRules: Set<MoveRule> = [MoveRule(rank: 0, file: 1)]
+    static let moveRules: Set<MoveRule> = [MoveRule(rank: 1, file: 0)]
     static let maxCount: Int = 8
     static let point: Int = 1
 
     let color: PieceColor
 
-    /// ``Pawn``이 최초에 위치할 수 있는 rank
+    /// 색상별 ``Pawn``이 최초에 위치할 수 있는 rank
     var initialRank: Int {
         switch color {
         case .black:
@@ -30,13 +30,17 @@ extension Pawn {
         from location: Board.Location
     ) -> [Board.Location] {
         guard let moveRule = Self.moveRules.first else { return [] }
+        var destination: Board.Location
 
         switch color {
         case .black:
-            return [location + moveRule]
+            destination = location + moveRule
 
         case .white:
-            return [location - moveRule]
+            destination = location - moveRule
         }
+
+        guard destination.isValid else { return [] }
+        return [destination]
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -12,6 +12,7 @@ struct Pawn: Piece {
 
     let color: PieceColor
 
+    /// ``Pawn``이 최초에 위치할 수 있는 rank
     var initialRank: Int {
         switch color {
         case .black:

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Pawn.swift
@@ -10,13 +10,13 @@ struct Pawn: Piece {
 
     let color: PieceColor
 
-    var initialRankIndex: Int {
+    var initialRank: Int {
         switch color {
         case .black:
-            return 1
+            return 2
 
         case .white:
-            return 6
+            return 7
         }
     }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -5,6 +5,7 @@
 //  Created by Geonhee on 2022/09/28.
 //
 
+/// 체스말 타입이 준수하는 프로토콜. 체스말이 가지는 기본 요건을 정의하고 있다.
 protocol Piece {
 
     /// 이동할 수 있는 규칙 모음. 자세한 내용은 ``MoveRule``을 참고한다.
@@ -17,6 +18,7 @@ protocol Piece {
     var color: PieceColor { get }
     /// 체스말이 잡혔을 때 획득할 수 있는 점수. `point` 타입 상수를 참조하여 반환한다.
     var point: Int { get }
+    /// 체스말을 콘솔에 표현할 때 사용하는 표식
     var asSymbol: String { get }
 
     /// 입력된 위치에서 이동할 수 있는 위치 후보를 반환한다.
@@ -59,6 +61,7 @@ struct MoveRule: Hashable {
     let file: Int
 }
 
+/// 체스말을 콘솔에 표현할 때 사용하는 표식을 모두 정의한 타입.
 enum PieceSymbol: String {
     case blackPawn = "♟"
     case whitePawn = "♙"

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -6,10 +6,13 @@
 //
 
 protocol Piece {
+    /// 체스판에 존재할 수 있는 최대 개수
+    static var maxCount: Int { get }
+
     var color: PieceColor { get }
 }
 
-enum PieceColor {
+enum PieceColor: CaseIterable {
     case black
     case white
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -7,7 +7,7 @@
 
 protocol Piece {
 
-    /// 이동할 수 있는 규칙. 예) (1, 2) -> Rank 1, File 2
+    /// 이동할 수 있는 규칙 모음. 자세한 내용은 ``MoveRule``을 참고한다.
     static var moveRules: Set<MoveRule> { get }
     /// 체스판에 존재할 수 있는 최대 개수
     static var maxCount: Int { get }
@@ -15,25 +15,14 @@ protocol Piece {
     static var point: Int { get }
 
     var color: PieceColor { get }
-    /// 체스말이 잡혔을 때 획득할 수 있는 점수. ``Piece/point`` 타입 상수를 참조하여 반환한다.
+    /// 체스말이 잡혔을 때 획득할 수 있는 점수. `point` 타입 상수를 참조하여 반환한다.
     var point: Int { get }
 
     /// 입력된 위치에서 이동할 수 있는 위치 후보를 반환한다.
     func movableLocations(from location: Board.Location) -> [Board.Location]
 }
 
-enum PieceColor: CaseIterable {
-    case black
-    case white
-}
-
-struct MoveRule: Hashable {
-    let rank: Int
-    let file: Int
-}
-
 extension Piece {
-
     var point: Int {
         switch self {
         case _ as Pawn:
@@ -42,4 +31,17 @@ extension Piece {
             return 0
         }
     }
+}
+
+enum PieceColor: CaseIterable {
+    case black
+    case white
+}
+
+/// 체스말의 이동 규칙을 정의한 타입.
+///
+///  예를 들어, `MoveRule(rank: 2, file:1)`은 해당 체스말이 rank로 2 칸, file로 1 칸 이동하는 규칙을 가지고 있다는 의미이다.
+struct MoveRule: Hashable {
+    let rank: Int
+    let file: Int
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -17,6 +17,7 @@ protocol Piece {
     var color: PieceColor { get }
     /// 체스말이 잡혔을 때 획득할 수 있는 점수. `point` 타입 상수를 참조하여 반환한다.
     var point: Int { get }
+    var asSymbol: String { get }
 
     /// 입력된 위치에서 이동할 수 있는 위치 후보를 반환한다.
     func movableLocations(from location: Board.Location) -> [Board.Location]
@@ -29,6 +30,18 @@ extension Piece {
             return Pawn.point
         default:
             return 0
+        }
+    }
+
+    var asSymbol: String {
+        switch self {
+        case _ as Pawn:
+            return color == .black
+                ? PieceSymbol.blackPawn.rawValue
+                : PieceSymbol.whitePawn.rawValue
+
+        default:
+            return PieceSymbol.empty.rawValue
         }
     }
 }
@@ -44,4 +57,10 @@ enum PieceColor: CaseIterable {
 struct MoveRule: Hashable {
     let rank: Int
     let file: Int
+}
+
+enum PieceSymbol: String {
+    case blackPawn = "♟"
+    case whitePawn = "♙"
+    case empty = "."
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -6,13 +6,40 @@
 //
 
 protocol Piece {
+
+    /// 이동할 수 있는 규칙. 예) (1, 2) -> Rank 1, File 2
+    static var moveRules: Set<MoveRule> { get }
     /// 체스판에 존재할 수 있는 최대 개수
     static var maxCount: Int { get }
+    /// 체스말이 잡혔을 때 획득할 수 있는 점수.
+    static var point: Int { get }
 
     var color: PieceColor { get }
+    /// 체스말이 잡혔을 때 획득할 수 있는 점수. ``Piece/point`` 타입 상수를 참조하여 반환한다.
+    var point: Int { get }
+
+    /// 입력된 위치에서 이동할 수 있는 위치 후보를 반환한다.
+    func movableLocations(from location: Board.Location) -> [Board.Location]
 }
 
 enum PieceColor: CaseIterable {
     case black
     case white
+}
+
+struct MoveRule: Hashable {
+    let rank: Int
+    let file: Int
+}
+
+extension Piece {
+
+    var point: Int {
+        switch self {
+        case _ as Pawn:
+            return Pawn.point
+        default:
+            return 0
+        }
+    }
 }

--- a/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
+++ b/SwiftChess/SwiftChess/Sources/Board/Model/Piece.swift
@@ -1,0 +1,15 @@
+//
+//  Piece.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+protocol Piece {
+    var color: PieceColor { get }
+}
+
+enum PieceColor {
+    case black
+    case white
+}

--- a/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
@@ -7,6 +7,9 @@
 
 extension Int {
 
+    /// 숫자를 배열의 index로 변환한다.
+    ///
+    /// 체스판의 rank, file과 같은 요소를 인덱스로 변환하는데 사용할 수 있다.
     var asIndex: Int {
         return self - 1
     }

--- a/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
@@ -13,4 +13,9 @@ extension Int {
     var asIndex: Int {
         return self - 1
     }
+
+    /// Ascii 값을 문자열 타입으로 변환하여 반환한다.
+    var asString: String {
+        return String(UnicodeScalar(self)!)
+    }
 }

--- a/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/Int+Extensions.swift
@@ -1,0 +1,13 @@
+//
+//  Int+Extensions.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+extension Int {
+
+    var asIndex: Int {
+        return self - 1
+    }
+}

--- a/SwiftChess/SwiftChess/Sources/Common/Occupiable.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/Occupiable.swift
@@ -1,0 +1,19 @@
+//
+//  Occupiable.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+protocol Occupiable {
+    var isEmpty: Bool { get }
+    var isNotEmpty: Bool { get }
+}
+
+extension Occupiable {
+    var isNotEmpty: Bool {
+        return !isEmpty
+    }
+}
+
+extension Array: Occupiable {}

--- a/SwiftChess/SwiftChess/Sources/Common/String+Extensions.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/String+Extensions.swift
@@ -11,10 +11,12 @@ extension String {
         return Int(UnicodeScalar(self)!.value)
     }
 
+    /// 문자열 숫자(예, "1")로 표현된 Rank를 정수형으로 바꾸어 반환한다.
     var asRankIndex: Int {
         return Int(self) ?? 0
     }
 
+    /// 문자열(예, "A")로 표현된 File을 정수형으로 바꾸어 반환한다.
     var asFileIndex: Int {
         return self.asAsciiValue - Board.Configuration.minimumFile.asAsciiValue + 1
     }

--- a/SwiftChess/SwiftChess/Sources/Common/String+Extensions.swift
+++ b/SwiftChess/SwiftChess/Sources/Common/String+Extensions.swift
@@ -1,0 +1,21 @@
+//
+//  String+Extensions.swift
+//  SwiftChess
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+extension String {
+
+    var asAsciiValue: Int {
+        return Int(UnicodeScalar(self)!.value)
+    }
+
+    var asRankIndex: Int {
+        return Int(self) ?? 0
+    }
+
+    var asFileIndex: Int {
+        return self.asAsciiValue - Board.Configuration.minimumFile.asAsciiValue + 1
+    }
+}

--- a/SwiftChess/SwiftChessTests/Board/BoardTesting.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTesting.swift
@@ -1,0 +1,74 @@
+//
+//  BoardTesting.swift
+//  SwiftChessTests
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+@testable import SwiftChess
+
+// swiftlint:disable comma identifier_name
+enum BoardTesting {
+    static let blackPawn = Pawn(color: .black)
+    static let whitePawn = Pawn(color: .white)
+    static let emptyMock: [[Piece?]] = [
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+        [nil, nil, nil, nil, nil, nil, nil, nil],
+    ]
+    static let topLeftBlackPawnMock: [[Piece?]] = [
+        [blackPawn, nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+    ]
+    static let topLeftBlockedPawnsMock: [[Piece?]] = [
+        [blackPawn, nil, nil, nil, nil, nil, nil, nil],
+        [blackPawn, nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+    ]
+    static let topLeftEngagedPawnsMock: [[Piece?]] = [
+        [blackPawn, nil, nil, nil, nil, nil, nil, nil],
+        [whitePawn, nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+    ]
+    static let topLeftWhitePawnMock: [[Piece?]] = [
+        [whitePawn, nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+        [nil      , nil, nil, nil, nil, nil, nil, nil],
+    ]
+}
+
+extension Board.Location {
+    /// invalid location
+    static let A0 = Self(rank: 0, file: 1)
+    static let A1 = Self(rank: 1, file: 1)
+    static let A2 = Self(rank: 2, file: 1)
+    static let D4 = Self(rank: 4, file: 4)
+    static let D5 = Self(rank: 5, file: 4)
+}
+// swiftlint:enable comma identifier_name

--- a/SwiftChess/SwiftChessTests/Board/BoardTesting.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTesting.swift
@@ -68,7 +68,15 @@ extension Board.Location {
     static let A0 = Self(rank: 0, file: 1)
     static let A1 = Self(rank: 1, file: 1)
     static let A2 = Self(rank: 2, file: 1)
+    static let A7 = Self(rank: 7, file: 1)
+    static let A8 = Self(rank: 8, file: 1)
+    static let B1 = Self(rank: 1, file: 2)
     static let D4 = Self(rank: 4, file: 4)
     static let D5 = Self(rank: 5, file: 4)
+    static let G1 = Self(rank: 1, file: 7)
+    static let G8 = Self(rank: 8, file: 7)
+    static let H1 = Self(rank: 1, file: 8)
+    static let H7 = Self(rank: 7, file: 8)
+    static let H8 = Self(rank: 8, file: 8)
 }
 // swiftlint:enable comma identifier_name

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -55,7 +55,7 @@ extension Board {
 
     func rank(_ rank: Int) throws -> [Piece?] {
         guard (1...Self.Configuration.size.rank).contains(rank) else {
-            throw BoardError.invalidRank
+            throw BoardError.invalidRank(rank)
         }
         return status[rank.asIndex]
     }

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -194,6 +194,23 @@ final class BoardTests: XCTestCase {
             )
         }
     }
+
+    func test_보드초기화후_체스판을그래픽으로나타내면_예상한대로출력된다() {
+        let expectedGraphicalRepresentation = """
+        ........
+        ♟♟♟♟♟♟♟♟
+        ........
+        ........
+        ........
+        ........
+        ♙♙♙♙♙♙♙♙
+        ........
+        """
+
+        let currentGraphicalRepresentation = sut?.display()
+
+        XCTAssertEqual(currentGraphicalRepresentation, expectedGraphicalRepresentation)
+    }
 }
 
 extension Board {

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -49,6 +49,151 @@ final class BoardTests: XCTestCase {
         XCTAssertEqual(existingPawns?.black, expectedPawnCount)
         XCTAssertEqual(existingPawns?.white, expectedPawnCount)
     }
+
+    func test_체스판초기화후_점수를측정하면_각진영의점수는0이다() {
+        let expectedPoints = (black: 0, white: 0)
+
+        let currentPoints = sut?.currentPoints()
+
+        XCTAssertEqual(currentPoints?.black, expectedPoints.black)
+        XCTAssertEqual(currentPoints?.white, expectedPoints.white)
+    }
+
+    func test_각진영에Pawn이하나씩남아있을때_점수를측정하면_모든진영의점수는7이다() {
+        let sut = Board(status: BoardTesting.topLeftEngagedPawnsMock)
+        let expectedPoint = 7
+
+        let currentPoints = sut.currentPoints()
+
+        XCTAssertEqual(currentPoints.black, expectedPoint)
+        XCTAssertEqual(currentPoints.white, expectedPoint)
+    }
+
+    func test_체스판에말이없을때_점수를측정하면_각진영모두최대점수이다() {
+        let sut = Board(status: BoardTesting.emptyMock)
+        let expectedPoint = Board.Configuration.totalAvailablePoints
+
+        let currentPoints = sut.currentPoints()
+
+        XCTAssertEqual(currentPoints.black, expectedPoint)
+        XCTAssertEqual(currentPoints.white, expectedPoint)
+    }
+
+    func test_흑색Pawn은_rank가늘어나는방향으로한칸만이동할수있다() {
+        let blackPawn = Pawn(color: .black)
+        let movableLocations = blackPawn.movableLocations(from: .D4)
+
+        XCTAssertEqual(movableLocations.count, 1)
+        XCTAssertEqual(movableLocations.first, .D5)
+    }
+
+    func test_백색Pawn은_rank가줄어드는방향으로한칸만이동할수있다() {
+        let whitePawn = Pawn(color: .white)
+        let movableLocations = whitePawn.movableLocations(from: .D5)
+
+        XCTAssertEqual(movableLocations.count, 1)
+        XCTAssertEqual(movableLocations.first, .D4)
+    }
+
+    func test_흑색진영이백색Pawn을잡으면_흑색진영이1점을얻는다() throws {
+        let sut = Board(status: BoardTesting.topLeftEngagedPawnsMock)
+        let initialPawnCounts = sut.pieceCount(for: Pawn.self)
+        let initialPoints = sut.currentPoints()
+        XCTAssertEqual(initialPawnCounts.black, 1)
+        XCTAssertEqual(initialPawnCounts.white, 1)
+        XCTAssertEqual(initialPoints.black, 7)
+        XCTAssertEqual(initialPoints.white, 7)
+
+        try sut.move(from: .A1, to: .A2)
+
+        let currentPawnCounts = sut.pieceCount(for: Pawn.self)
+        let currentPoints = sut.currentPoints()
+        XCTAssertEqual(currentPawnCounts.black, initialPawnCounts.black)
+        XCTAssertEqual(currentPawnCounts.white, initialPawnCounts.white - 1)
+        XCTAssertEqual(currentPoints.black, initialPoints.black + 1)
+        XCTAssertEqual(currentPoints.white, initialPoints.white)
+    }
+
+    func test_백색진영이흑색Pawn을잡으면_백색진영이1점을얻는다() throws {
+        let sut = Board(status: BoardTesting.topLeftEngagedPawnsMock)
+        let initialPawnCounts = sut.pieceCount(for: Pawn.self)
+        let initialPoints = sut.currentPoints()
+        XCTAssertEqual(initialPawnCounts.black, 1)
+        XCTAssertEqual(initialPawnCounts.white, 1)
+        XCTAssertEqual(initialPoints.black, 7)
+        XCTAssertEqual(initialPoints.white, 7)
+
+        try sut.move(from: .A2, to: .A1)
+
+        let currentPawnCounts = sut.pieceCount(for: Pawn.self)
+        let currentPoints = sut.currentPoints()
+        XCTAssertEqual(currentPawnCounts.black, initialPawnCounts.black - 1)
+        XCTAssertEqual(currentPawnCounts.white, initialPawnCounts.white)
+        XCTAssertEqual(currentPoints.black, initialPoints.black)
+        XCTAssertEqual(currentPoints.white, initialPoints.white + 1)
+    }
+
+    func test_Pawn이상대진영의끝으로이동하면_이동할수있는곳이없다() {
+        let whitePawn = Pawn(color: .white)
+        let movableLocations = whitePawn.movableLocations(from: .A1)
+
+        XCTAssertTrue(movableLocations.isEmpty)
+    }
+
+    func test_체스판안에있지않은출발점을지정하면_이동시킬수없다() {
+        let sut = Board(status: BoardTesting.topLeftBlackPawnMock)
+
+        XCTAssertThrowsError(try sut.move(from: .A0, to: .A1)) { error in
+            XCTAssertEqual(
+                error as? BoardError,
+                .invalidStartPoint(.A0)
+            )
+        }
+    }
+
+    func test_체스판안에있지않은목적지를지정하면_이동시킬수없다() {
+        let sut = Board(status: BoardTesting.topLeftWhitePawnMock)
+
+        XCTAssertThrowsError(try sut.move(from: .A1, to: .A0)) { error in
+            XCTAssertEqual(
+                error as? BoardError,
+                .invalidEndPoint(.A0)
+            )
+        }
+    }
+
+    func test_출발점과목적지가동일하면_이동시킬수없다() {
+        let sut = Board(status: BoardTesting.topLeftWhitePawnMock)
+
+        XCTAssertThrowsError(try sut.move(from: .A1, to: .A1)) { error in
+            XCTAssertEqual(
+                error as? BoardError,
+                .startEndPointShouldNotBeIdentical
+            )
+        }
+    }
+
+    func test_출발점에체스말이없으면_이동시킬수없다() {
+        let sut = Board(status: BoardTesting.emptyMock)
+
+        XCTAssertThrowsError(try sut.move(from: .A1, to: .A2)) { error in
+            XCTAssertEqual(
+                error as? BoardError,
+                .pieceNotExistsAtStartPoint(.A1)
+            )
+        }
+    }
+
+    func test_같은색상의말이목적지에있으면_이동할수없다() {
+        let sut = Board(status: BoardTesting.topLeftBlockedPawnsMock)
+
+        XCTAssertThrowsError(try sut.move(from: .A1, to: .A2)) { error in
+            XCTAssertEqual(
+                error as? BoardError,
+                .identicalColoredPieceAlreadyExists(endPoint: .A2)
+            )
+        }
+    }
 }
 
 extension Board {

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -1,0 +1,24 @@
+//
+//  BoardTests.swift
+//  SwiftChessTests
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+import XCTest
+@testable import SwiftChess
+
+final class BoardTests: XCTestCase {
+
+    private var sut: Board?
+
+    override func setUp() {
+        super.setUp()
+        sut = Board()
+    }
+
+    override func tearDown() {
+        sut = nil
+        super.tearDown()
+    }
+}

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -21,4 +21,62 @@ final class BoardTests: XCTestCase {
         sut = nil
         super.tearDown()
     }
+
+    func test_흑색Pawn의최초생성위치는_2rank이다() throws {
+        let expectedPieceColor = PieceColor.black
+        let secondRank = try sut?.rank(2)
+
+        secondRank?.forEach { piece in
+            XCTAssertTrue(piece is Pawn)
+            XCTAssertEqual(piece?.color, expectedPieceColor)
+        }
+    }
+
+    func test_백색Pawn의최초생성위치는_7rank이다() throws {
+        let expectedPieceColor = PieceColor.white
+        let secondRank = try sut?.rank(7)
+
+        secondRank?.forEach { piece in
+            XCTAssertTrue(piece is Pawn)
+            XCTAssertEqual(piece?.color, expectedPieceColor)
+        }
+    }
+
+    func test_색상별최초Pawn의생성개수는_8개이다() {
+        let expectedPawnCount = 8
+        let existingPawns = sut?.pieceCount(for: Pawn.self)
+
+        XCTAssertEqual(existingPawns?.black, expectedPawnCount)
+        XCTAssertEqual(existingPawns?.white, expectedPawnCount)
+    }
+}
+
+extension Board {
+
+    func rank(_ rank: Int) throws -> [Piece?] {
+        guard (1...Self.Configuration.size.rank).contains(rank) else {
+            throw BoardError.invalidRank
+        }
+        return status[rank.asIndex]
+    }
+
+    func pieceCount<P: Piece>(for pieceType: P.Type) -> (black: Int, white: Int) {
+        let existingPieces = status
+            .flatMap { $0.compactMap { $0 } }
+            .filter { $0 is P }
+
+        var pieces = (black: 0, white: 0)
+
+        existingPieces.forEach { piece in
+            switch piece.color {
+            case .black:
+                pieces.black += 1
+
+            case .white:
+                pieces.white += 1
+            }
+        }
+
+        return pieces
+    }
 }

--- a/SwiftChess/SwiftChessTests/Board/BoardTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/BoardTests.swift
@@ -22,6 +22,8 @@ final class BoardTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - 초기화
+
     func test_흑색Pawn의최초생성위치는_2rank이다() throws {
         let expectedPieceColor = PieceColor.black
         let secondRank = try sut?.rank(2)
@@ -49,6 +51,8 @@ final class BoardTests: XCTestCase {
         XCTAssertEqual(existingPawns?.black, expectedPawnCount)
         XCTAssertEqual(existingPawns?.white, expectedPawnCount)
     }
+
+    // MARK: - 점수 측정
 
     func test_체스판초기화후_점수를측정하면_각진영의점수는0이다() {
         let expectedPoints = (black: 0, white: 0)
@@ -79,6 +83,8 @@ final class BoardTests: XCTestCase {
         XCTAssertEqual(currentPoints.white, expectedPoint)
     }
 
+    // MARK: - 이동
+
     func test_흑색Pawn은_rank가늘어나는방향으로한칸만이동할수있다() {
         let blackPawn = Pawn(color: .black)
         let movableLocations = blackPawn.movableLocations(from: .D4)
@@ -93,6 +99,13 @@ final class BoardTests: XCTestCase {
 
         XCTAssertEqual(movableLocations.count, 1)
         XCTAssertEqual(movableLocations.first, .D4)
+    }
+
+    func test_Pawn이상대진영의끝으로이동하면_이동할수있는곳이없다() {
+        let whitePawn = Pawn(color: .white)
+        let movableLocations = whitePawn.movableLocations(from: .A1)
+
+        XCTAssertTrue(movableLocations.isEmpty)
     }
 
     func test_흑색진영이백색Pawn을잡으면_흑색진영이1점을얻는다() throws {
@@ -131,13 +144,6 @@ final class BoardTests: XCTestCase {
         XCTAssertEqual(currentPawnCounts.white, initialPawnCounts.white)
         XCTAssertEqual(currentPoints.black, initialPoints.black)
         XCTAssertEqual(currentPoints.white, initialPoints.white + 1)
-    }
-
-    func test_Pawn이상대진영의끝으로이동하면_이동할수있는곳이없다() {
-        let whitePawn = Pawn(color: .white)
-        let movableLocations = whitePawn.movableLocations(from: .A1)
-
-        XCTAssertTrue(movableLocations.isEmpty)
     }
 
     func test_체스판안에있지않은출발점을지정하면_이동시킬수없다() {
@@ -194,6 +200,8 @@ final class BoardTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - 출력
 
     func test_보드초기화후_체스판을그래픽으로나타내면_예상한대로출력된다() {
         let expectedGraphicalRepresentation = """

--- a/SwiftChess/SwiftChessTests/Board/Component/CommandParserTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/Component/CommandParserTests.swift
@@ -1,0 +1,122 @@
+//
+//  CommandParserTests.swift
+//  SwiftChessTests
+//
+//  Created by Geonhee on 2022/09/29.
+//
+
+import XCTest
+@testable import SwiftChess
+
+final class CommandParserTests: XCTestCase {
+
+    func test_A1에서A2로이동하는유효한입력을하면_A1시작점과A2목적지로파싱된다() throws {
+        let command = "A1->A2"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .A1)
+        XCTAssertEqual(parsed.endPoint, .A2)
+    }
+
+    func test_A7에서A8로이동하는유효한입력을하면_A7시작점과A8목적지로파싱된다() throws {
+        let command = "A7->A8"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .A7)
+        XCTAssertEqual(parsed.endPoint, .A8)
+    }
+
+    func test_B1에서A1으로이동하는유효한입력을하면_B1시작점과A1목적지로파싱된다() throws {
+        let command = "A1->B1"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .A1)
+        XCTAssertEqual(parsed.endPoint, .B1)
+    }
+
+    func test_G1에서H1으로이동하는유효한입력을하면_G1시작점과H1목적지로파싱된다() throws {
+        let command = "G1->H1"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .G1)
+        XCTAssertEqual(parsed.endPoint, .H1)
+    }
+
+    func test_H7에서H8로이동하는유효한입력을하면_H7시작점과H8목적지로파싱된다() throws {
+        let command = "H7->H8"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .H7)
+        XCTAssertEqual(parsed.endPoint, .H8)
+    }
+
+    func test_G8에서H8로이동하는유효한입력을하면_H7시작점과H8목적지로파싱된다() throws {
+        let command = "G8->H8"
+
+        let parsed = try CommandParser.parse(command)
+
+        XCTAssertEqual(parsed.startPoint, .G8)
+        XCTAssertEqual(parsed.endPoint, .H8)
+    }
+
+    func test_지정되지구분형식으로명령어를입력하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "A1>A2"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_A1에서A0로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "A1->A0"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_H1에서H0로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "H1->H0"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_H1에서I1으로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "H1->I1"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_A8에서A9으로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "A8->A9"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_H8에서H9으로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "H8->H9"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+
+    func test_H8에서I8로이동하는유효하지않은입력을하면_파싱에실패하여검증실패에러를던진다() throws {
+        let command = "H8->I8"
+
+        XCTAssertThrowsError(try CommandParser.parse(command)) { error in
+            XCTAssertEqual(error as? CommandParserError, .validationFailed)
+        }
+    }
+}

--- a/SwiftChess/SwiftChessTests/Board/Model/PawnTests.swift
+++ b/SwiftChess/SwiftChessTests/Board/Model/PawnTests.swift
@@ -1,0 +1,24 @@
+//
+//  PawnTests.swift
+//  SwiftChessTests
+//
+//  Created by Geonhee on 2022/09/28.
+//
+
+import XCTest
+@testable import SwiftChess
+
+final class PawnTests: XCTestCase {
+
+    func test_흑색Pawn의최초Rank는_2이다() {
+        let blackPawn = Pawn(color: .black)
+
+        XCTAssertEqual(blackPawn.initialRank, 2)
+    }
+
+    func test_백색Pawn의최초Rank는_7이다() {
+        let whitePawn = Pawn(color: .white)
+
+        XCTAssertEqual(whitePawn.initialRank, 7)
+    }
+}


### PR DESCRIPTION
# Class diagram 및 구조설명

![image](https://user-images.githubusercontent.com/69730931/192848780-4ef726de-3f7b-4e78-a736-d6ed56aff1ce.png)

| 타입 이름 | 역할 |
|--|--|
|`CommandReader`|사용자 입력 읽기 - 향후 요구사항에 따라 보완|
|`CommandParser`|사용자 입력 검증 및 파싱|
|`MoveCommand`|사용자가 입력한 출발점과 목적지를 가진 타입|
|`Board`|체스판 초기화, 체스말 이동, 점수 계산, 콘솔 출력 (`Board`)|
|`Board.Configuration`|체스판 구성에 필요한 상수값 정의|
|`Board.Location`|체스판 내 위치를 정의하는 타입|
|`Piece`|체스말 타입이 준수하는 프로토콜. 체스말이 가지는 기본 요건 정의|
|`Pawn`|체스말 폰|

## 사용자 입력 읽기 및 파싱

- `CommandReader`가 사용자 입력을 받고 `CommandParser`가 문자열로 된 사용자 입력을  앱 도메인에서 이용하는 모델(`MoveCommand`) 로 변경합니다.
- `MoveCommand`는 출발점과 목적지를 가진 모델로, `rank`와 `file`값을 정수형으로 가지고 있습니다.

## 체스판 초기화, 체스말 이동, 점수 계산 및 콘솔 출력 (`Board`)

- 체스판 타입인 `Board`는 요구사항대로 체스판을 초기화하는 이니셜라이저와 테스트를 위해 주어진 체스판 상태로 초기화하는 이니셜라이저로 생성자를 구성하였습니다.
- 체스판 위의 체스말을 이동시키는 `move(from:to:)`, 점수를 계산하여 출력하는 `currentPoints()`와 콘솔에 체스판 현황을 출력하는 `display()` 메서드를 제공합니다.

## 체스말

현재는 `Pawn`이 유일한 체스말 타입입니다. `Pawn`은 체스말 타입의 요구사항을 명세한 `Piece` 프로토콜을 준수합니다. `Piece` 프로토콜은 체스말마다 다르게 구현될 필요가 있는 사항이 아니라면 일부 기본구현을 제공합니다.

# 폴더 구조

향후 모듈을 분리하기 용이하도록 유사한 기능을 수행하는 타입을 그룹화하기보다 하나의 기능군을 이루는 타입들을 그룹화하려 노력하였습니다.

```
.
├── SwiftChess
│   ├── Resources
│   ├── Sources
│   │   ├── Application
│   │   │   ├── AppDelegate.swift
│   │   │   └── SceneDelegate.swift
│   │   ├── Board
│   │   │   ├── Board.swift
│   │   │   ├── Component
│   │   │   │   ├── CommandParser.swift
│   │   │   │   └── CommandReader.swift
│   │   │   └── Model
│   │   │       ├── Pawn.swift
│   │   │       └── Piece.swift
│   │   ├── Common
│   │   └── Home
│   └── SupportingFiles
├── SwiftChessTests
└── SwiftChessUITests
```

# 단위테스트

- 타입에서 공개한 메서드를 검증하였으며 향후 체스판의 끝지점에서 일어날 수 있는 버그를 조기에 감지하고자 체스판 끝에서의 이동 명령, 파싱과 같은 테스트를 중점적으로 작성했습니다.
- 주어진 상황, 변경 또는 실행, 결과를 나누기 위해 테스트 메서드의 이름에 언더스코어(_)를 사용했습니다. 테스트 메서드 코드 상에는 줄바꿈으로 구분되어 있습니다.
- 테스트 명세는 아래 테스트 목록을 참고해주세요.

![image](https://user-images.githubusercontent.com/69730931/192853251-bd38d051-41f7-498c-8811-aa2752130788.png)

# 기타

각 메서드와 프로퍼티를 어떤 의도로 만들었는지, 어떤 입력과 결과를 기대하는지를 문서화 주석에 작성해두었습니다.
