### PR TITLE
[Ray] 체스보드와 체스말 2

### DIFF
--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		48AABCA528E13D360085F577 /* ChessGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA428E13D360085F577 /* ChessGame.swift */; };
 		48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA728E16A3D0085F577 /* Array+ext.swift */; };
 		48AABCAA28E17A820085F577 /* BoardMovePieceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */; };
+		48BA3A3B28EB170F006BCA3D /* Queen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BA3A3A28EB170F006BCA3D /* Queen.swift */; };
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
 		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
@@ -67,6 +68,7 @@
 		48AABCA428E13D360085F577 /* ChessGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGame.swift; sourceTree = "<group>"; };
 		48AABCA728E16A3D0085F577 /* Array+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ext.swift"; sourceTree = "<group>"; };
 		48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePieceTest.swift; sourceTree = "<group>"; };
+		48BA3A3A28EB170F006BCA3D /* Queen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queen.swift; sourceTree = "<group>"; };
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				48AABC9A28DE99090085F577 /* Board.swift */,
 				48BC37CC28E9C9B70040F287 /* Bishop.swift */,
 				48BC37D028EA71DD0040F287 /* Rook.swift */,
+				48BA3A3A28EB170F006BCA3D /* Queen.swift */,
 			);
 			path = Chess;
 			sourceTree = "<group>";
@@ -321,6 +324,7 @@
 				48BC37D128EA71DD0040F287 /* Rook.swift in Sources */,
 				48AABC6E28DE90B70085F577 /* ViewController.swift in Sources */,
 				48AABC6A28DE90B70085F577 /* AppDelegate.swift in Sources */,
+				48BA3A3B28EB170F006BCA3D /* Queen.swift in Sources */,
 				48AABCA528E13D360085F577 /* ChessGame.swift in Sources */,
 				48AABC9B28DE99090085F577 /* Board.swift in Sources */,
 				48AABCA328DFFA8A0085F577 /* Piece.swift in Sources */,

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA728E16A3D0085F577 /* Array+ext.swift */; };
 		48AABCAA28E17A820085F577 /* BoardMovePieceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */; };
 		48BA3A3B28EB170F006BCA3D /* Queen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BA3A3A28EB170F006BCA3D /* Queen.swift */; };
+		48BA3A3D28EB1A52006BCA3D /* Knight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BA3A3C28EB1A52006BCA3D /* Knight.swift */; };
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
 		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
@@ -69,6 +70,7 @@
 		48AABCA728E16A3D0085F577 /* Array+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ext.swift"; sourceTree = "<group>"; };
 		48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePieceTest.swift; sourceTree = "<group>"; };
 		48BA3A3A28EB170F006BCA3D /* Queen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Queen.swift; sourceTree = "<group>"; };
+		48BA3A3C28EB1A52006BCA3D /* Knight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Knight.swift; sourceTree = "<group>"; };
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 				48BC37CC28E9C9B70040F287 /* Bishop.swift */,
 				48BC37D028EA71DD0040F287 /* Rook.swift */,
 				48BA3A3A28EB170F006BCA3D /* Queen.swift */,
+				48BA3A3C28EB1A52006BCA3D /* Knight.swift */,
 			);
 			path = Chess;
 			sourceTree = "<group>";
@@ -325,6 +328,7 @@
 				48AABC6E28DE90B70085F577 /* ViewController.swift in Sources */,
 				48AABC6A28DE90B70085F577 /* AppDelegate.swift in Sources */,
 				48BA3A3B28EB170F006BCA3D /* Queen.swift in Sources */,
+				48BA3A3D28EB1A52006BCA3D /* Knight.swift in Sources */,
 				48AABCA528E13D360085F577 /* ChessGame.swift in Sources */,
 				48AABC9B28DE99090085F577 /* Board.swift in Sources */,
 				48AABCA328DFFA8A0085F577 /* Piece.swift in Sources */,

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
 		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
+		48BC37D128EA71DD0040F287 /* Rock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D028EA71DD0040F287 /* Rock.swift */; };
+		48BC37D328EA77990040F287 /* RookTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D228EA77990040F287 /* RookTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -67,6 +69,8 @@
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
+		48BC37D028EA71DD0040F287 /* Rock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rock.swift; sourceTree = "<group>"; };
+		48BC37D228EA77990040F287 /* RookTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +139,7 @@
 				48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */,
 				48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */,
 				48BC37CE28EA6C050040F287 /* BishopTest.swift */,
+				48BC37D228EA77990040F287 /* RookTest.swift */,
 			);
 			path = "ray-chessTests";
 			sourceTree = "<group>";
@@ -174,6 +179,7 @@
 				48AABCA228DFFA8A0085F577 /* Piece.swift */,
 				48AABC9A28DE99090085F577 /* Board.swift */,
 				48BC37CC28E9C9B70040F287 /* Bishop.swift */,
+				48BC37D028EA71DD0040F287 /* Rock.swift */,
 			);
 			path = Chess;
 			sourceTree = "<group>";
@@ -309,6 +315,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48BC37D128EA71DD0040F287 /* Rock.swift in Sources */,
 				48AABC6E28DE90B70085F577 /* ViewController.swift in Sources */,
 				48AABC6A28DE90B70085F577 /* AppDelegate.swift in Sources */,
 				48AABCA528E13D360085F577 /* ChessGame.swift in Sources */,
@@ -326,6 +333,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */,
+				48BC37D328EA77990040F287 /* RookTest.swift in Sources */,
 				48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */,
 				48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */,
 				48AABC8128DE90BB0085F577 /* BoardSetPawnTest.swift in Sources */,

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		48AABCA528E13D360085F577 /* ChessGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA428E13D360085F577 /* ChessGame.swift */; };
 		48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA728E16A3D0085F577 /* Array+ext.swift */; };
 		48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */; };
+		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		48AABCA428E13D360085F577 /* ChessGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGame.swift; sourceTree = "<group>"; };
 		48AABCA728E16A3D0085F577 /* Array+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ext.swift"; sourceTree = "<group>"; };
 		48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePawnTest.swift; sourceTree = "<group>"; };
+		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +129,7 @@
 			children = (
 				48AABC8028DE90BB0085F577 /* BoardSetPawnTest.swift */,
 				48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */,
+				48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */,
 			);
 			path = "ray-chessTests";
 			sourceTree = "<group>";
@@ -316,6 +319,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */,
+				48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */,
 				48AABC8128DE90BB0085F577 /* BoardSetPawnTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -13,7 +13,7 @@
 		48AABC7128DE90B70085F577 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 48AABC6F28DE90B70085F577 /* Main.storyboard */; };
 		48AABC7328DE90BB0085F577 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 48AABC7228DE90BB0085F577 /* Assets.xcassets */; };
 		48AABC7628DE90BB0085F577 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 48AABC7428DE90BB0085F577 /* LaunchScreen.storyboard */; };
-		48AABC8128DE90BB0085F577 /* BoardSetPawnTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABC8028DE90BB0085F577 /* BoardSetPawnTest.swift */; };
+		48AABC8128DE90BB0085F577 /* BoardSetPieceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABC8028DE90BB0085F577 /* BoardSetPieceTest.swift */; };
 		48AABC8B28DE90BB0085F577 /* ray_chessUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABC8A28DE90BB0085F577 /* ray_chessUITests.swift */; };
 		48AABC8D28DE90BB0085F577 /* ray_chessUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABC8C28DE90BB0085F577 /* ray_chessUITestsLaunchTests.swift */; };
 		48AABC9B28DE99090085F577 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABC9A28DE99090085F577 /* Board.swift */; };
@@ -21,7 +21,7 @@
 		48AABCA328DFFA8A0085F577 /* Piece.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA228DFFA8A0085F577 /* Piece.swift */; };
 		48AABCA528E13D360085F577 /* ChessGame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA428E13D360085F577 /* ChessGame.swift */; };
 		48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA728E16A3D0085F577 /* Array+ext.swift */; };
-		48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */; };
+		48AABCAA28E17A820085F577 /* BoardMovePieceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */; };
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
 		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
@@ -56,7 +56,7 @@
 		48AABC7528DE90BB0085F577 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		48AABC7728DE90BB0085F577 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		48AABC7C28DE90BB0085F577 /* ray-chessTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ray-chessTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		48AABC8028DE90BB0085F577 /* BoardSetPawnTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSetPawnTest.swift; sourceTree = "<group>"; };
+		48AABC8028DE90BB0085F577 /* BoardSetPieceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardSetPieceTest.swift; sourceTree = "<group>"; };
 		48AABC8628DE90BB0085F577 /* ray-chessUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ray-chessUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		48AABC8A28DE90BB0085F577 /* ray_chessUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ray_chessUITests.swift; sourceTree = "<group>"; };
 		48AABC8C28DE90BB0085F577 /* ray_chessUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ray_chessUITestsLaunchTests.swift; sourceTree = "<group>"; };
@@ -65,7 +65,7 @@
 		48AABCA228DFFA8A0085F577 /* Piece.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Piece.swift; sourceTree = "<group>"; };
 		48AABCA428E13D360085F577 /* ChessGame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGame.swift; sourceTree = "<group>"; };
 		48AABCA728E16A3D0085F577 /* Array+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ext.swift"; sourceTree = "<group>"; };
-		48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePawnTest.swift; sourceTree = "<group>"; };
+		48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePieceTest.swift; sourceTree = "<group>"; };
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
@@ -135,8 +135,8 @@
 		48AABC7F28DE90BB0085F577 /* ray-chessTests */ = {
 			isa = PBXGroup;
 			children = (
-				48AABC8028DE90BB0085F577 /* BoardSetPawnTest.swift */,
-				48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */,
+				48AABC8028DE90BB0085F577 /* BoardSetPieceTest.swift */,
+				48AABCA928E17A820085F577 /* BoardMovePieceTest.swift */,
 				48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */,
 				48BC37CE28EA6C050040F287 /* BishopTest.swift */,
 				48BC37D228EA77990040F287 /* RookTest.swift */,
@@ -334,9 +334,9 @@
 			files = (
 				48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */,
 				48BC37D328EA77990040F287 /* RookTest.swift in Sources */,
-				48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */,
+				48AABCAA28E17A820085F577 /* BoardMovePieceTest.swift in Sources */,
 				48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */,
-				48AABC8128DE90BB0085F577 /* BoardSetPawnTest.swift in Sources */,
+				48AABC8128DE90BB0085F577 /* BoardSetPieceTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA728E16A3D0085F577 /* Array+ext.swift */; };
 		48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */; };
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
+		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
+		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +65,8 @@
 		48AABCA728E16A3D0085F577 /* Array+ext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+ext.swift"; sourceTree = "<group>"; };
 		48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardMovePawnTest.swift; sourceTree = "<group>"; };
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
+		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
+		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +134,7 @@
 				48AABC8028DE90BB0085F577 /* BoardSetPawnTest.swift */,
 				48AABCA928E17A820085F577 /* BoardMovePawnTest.swift */,
 				48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */,
+				48BC37CE28EA6C050040F287 /* BishopTest.swift */,
 			);
 			path = "ray-chessTests";
 			sourceTree = "<group>";
@@ -168,6 +173,7 @@
 				48AABCA428E13D360085F577 /* ChessGame.swift */,
 				48AABCA228DFFA8A0085F577 /* Piece.swift */,
 				48AABC9A28DE99090085F577 /* Board.swift */,
+				48BC37CC28E9C9B70040F287 /* Bishop.swift */,
 			);
 			path = Chess;
 			sourceTree = "<group>";
@@ -308,6 +314,7 @@
 				48AABCA528E13D360085F577 /* ChessGame.swift in Sources */,
 				48AABC9B28DE99090085F577 /* Board.swift in Sources */,
 				48AABCA328DFFA8A0085F577 /* Piece.swift in Sources */,
+				48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */,
 				48AABCA828E16A3D0085F577 /* Array+ext.swift in Sources */,
 				48AABC9D28DE9B280085F577 /* Pawn.swift in Sources */,
 				48AABC6C28DE90B70085F577 /* SceneDelegate.swift in Sources */,
@@ -318,6 +325,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */,
 				48AABCAA28E17A820085F577 /* BoardMovePawnTest.swift in Sources */,
 				48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */,
 				48AABC8128DE90BB0085F577 /* BoardSetPawnTest.swift in Sources */,

--- a/ray-chess/ray-chess.xcodeproj/project.pbxproj
+++ b/ray-chess/ray-chess.xcodeproj/project.pbxproj
@@ -25,8 +25,9 @@
 		48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */; };
 		48BC37CD28E9C9B70040F287 /* Bishop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CC28E9C9B70040F287 /* Bishop.swift */; };
 		48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37CE28EA6C050040F287 /* BishopTest.swift */; };
-		48BC37D128EA71DD0040F287 /* Rock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D028EA71DD0040F287 /* Rock.swift */; };
+		48BC37D128EA71DD0040F287 /* Rook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D028EA71DD0040F287 /* Rook.swift */; };
 		48BC37D328EA77990040F287 /* RookTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D228EA77990040F287 /* RookTest.swift */; };
+		48BC37D528EAAEB60040F287 /* ChessGameTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48BC37D428EAAEB60040F287 /* ChessGameTest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,8 +70,9 @@
 		48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardBasicTest.swift; sourceTree = "<group>"; };
 		48BC37CC28E9C9B70040F287 /* Bishop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bishop.swift; sourceTree = "<group>"; };
 		48BC37CE28EA6C050040F287 /* BishopTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BishopTest.swift; sourceTree = "<group>"; };
-		48BC37D028EA71DD0040F287 /* Rock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rock.swift; sourceTree = "<group>"; };
+		48BC37D028EA71DD0040F287 /* Rook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rook.swift; sourceTree = "<group>"; };
 		48BC37D228EA77990040F287 /* RookTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RookTest.swift; sourceTree = "<group>"; };
+		48BC37D428EAAEB60040F287 /* ChessGameTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChessGameTest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -140,6 +142,7 @@
 				48BC37CA28E9C67B0040F287 /* BoardBasicTest.swift */,
 				48BC37CE28EA6C050040F287 /* BishopTest.swift */,
 				48BC37D228EA77990040F287 /* RookTest.swift */,
+				48BC37D428EAAEB60040F287 /* ChessGameTest.swift */,
 			);
 			path = "ray-chessTests";
 			sourceTree = "<group>";
@@ -179,7 +182,7 @@
 				48AABCA228DFFA8A0085F577 /* Piece.swift */,
 				48AABC9A28DE99090085F577 /* Board.swift */,
 				48BC37CC28E9C9B70040F287 /* Bishop.swift */,
-				48BC37D028EA71DD0040F287 /* Rock.swift */,
+				48BC37D028EA71DD0040F287 /* Rook.swift */,
 			);
 			path = Chess;
 			sourceTree = "<group>";
@@ -315,7 +318,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				48BC37D128EA71DD0040F287 /* Rock.swift in Sources */,
+				48BC37D128EA71DD0040F287 /* Rook.swift in Sources */,
 				48AABC6E28DE90B70085F577 /* ViewController.swift in Sources */,
 				48AABC6A28DE90B70085F577 /* AppDelegate.swift in Sources */,
 				48AABCA528E13D360085F577 /* ChessGame.swift in Sources */,
@@ -334,6 +337,7 @@
 			files = (
 				48BC37CF28EA6C050040F287 /* BishopTest.swift in Sources */,
 				48BC37D328EA77990040F287 /* RookTest.swift in Sources */,
+				48BC37D528EAAEB60040F287 /* ChessGameTest.swift in Sources */,
 				48AABCAA28E17A820085F577 /* BoardMovePieceTest.swift in Sources */,
 				48BC37CB28E9C67B0040F287 /* BoardBasicTest.swift in Sources */,
 				48AABC8128DE90BB0085F577 /* BoardSetPieceTest.swift in Sources */,

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -26,7 +26,7 @@ class Bishop: Piecable {
         }
     }
 
-    func reachablePosition() -> [Piece.Position] {
+    func reachablePositions() -> [Piece.Position] {
         let maximumReach = max(
             (File.H.rawValue) - position.file.rawValue,
             (Rank.eight.rawValue) - position.rank.rawValue,

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -58,9 +58,9 @@ class Bishop: Piecable {
 
     func initializablePositions() -> [Piece.Position] {
         switch color {
-        case .white:
-            return [Piece.Position(rank: .one, file: .C), Piece.Position(rank: .one, file: .F)]
         case .black:
+            return [Piece.Position(rank: .one, file: .C), Piece.Position(rank: .one, file: .F)]
+        case .white:
             return [Piece.Position(rank: .eight, file: .C), Piece.Position(rank: .eight, file: .F)]
         }
     }

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -6,3 +6,72 @@
 //
 
 import Foundation
+
+class Bishop: Piecable {
+    var position: Piece.Position
+    var color: Piece.Color
+    var name: String
+    var maxCount: Int = 2
+
+    init(color: Piece.Color, position: Piece.Position) {
+        self.color = color
+        self.position = position
+        self.maxCount = 8
+
+        switch color {
+        case .white:
+            self.name = "U+265D"
+        case .black:
+            self.name = "U+2657"
+        }
+    }
+
+    func reachablePosition() -> [Piece.Position] {
+        let maximumReach = max(
+            (File.H.rawValue) - position.file.rawValue,
+            (Rank.eight.rawValue) - position.rank.rawValue,
+            position.file.rawValue,
+            position.rank.rawValue
+        )
+        
+        var positions = [Piece.Position]()
+        for step in 1...maximumReach {
+            positions.append(contentsOf: getReachableDiagonalPostions(step: step))
+        }
+        return positions
+    }
+    
+    func getReachableDiagonalPostions(step: Int) -> [Piece.Position] {
+        var positions = [Piece.Position]()
+        
+        for i in [-1 * step, 1 * step] {
+            for j in [-1 * step, +1 * step] {
+                if let rank = position.rank.getPoint(added: i),
+                   let file = position.file.getPoint(added: j) {
+                    positions.append(Piece.Position(rank: rank, file: file))
+                }
+            }
+        }
+        
+        return positions
+    }
+
+    func initializablePositions() -> [Piece.Position] {
+        switch color {
+        case .white:
+            return [Piece.Position(rank: .one, file: .C), Piece.Position(rank: .one, file: .F)]
+        case .black:
+            return [Piece.Position(rank: .eight, file: .C), Piece.Position(rank: .eight, file: .F)]
+        }
+    }
+
+    func getSymbol() -> String {
+        switch color {
+
+        case .white:
+            return "♗"
+        case .black:
+            return "♝"
+        }
+    }
+}

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -1,0 +1,8 @@
+//
+//  Bishop.swift
+//  ray-chess
+//
+//  Created by 김상진 on 2022/10/02.
+//
+
+import Foundation

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -12,6 +12,7 @@ class Bishop: Piecable {
     var color: Piece.Color
     var name: String
     var maxCount: Int = 2
+    var moveType: Piece.MoveType = .line
 
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color
@@ -25,36 +26,40 @@ class Bishop: Piecable {
             self.name = "U+2657"
         }
     }
-
-    func reachablePositions() -> [Piece.Position] {
-        let maximumReach = max(
-            (File.H.rawValue) - position.file.rawValue,
-            (Rank.eight.rawValue) - position.rank.rawValue,
-            position.file.rawValue,
-            position.rank.rawValue
-        )
-        
-        var positions = [Piece.Position]()
-        for step in 1...maximumReach {
-            positions.append(contentsOf: getReachableDiagonalPostions(step: step))
-        }
-        return positions
-    }
     
-    func getReachableDiagonalPostions(step: Int) -> [Piece.Position] {
-        var positions = [Piece.Position]()
-        
-        for i in [-1 * step, 1 * step] {
-            for j in [-1 * step, +1 * step] {
-                if let rank = position.rank.getPoint(added: i),
-                   let file = position.file.getPoint(added: j) {
-                    positions.append(Piece.Position(rank: rank, file: file))
-                }
-            }
-        }
-        
-        return positions
+    func reachableDirections() -> [Piece.Direction] {
+        return [.topRight, .rightBottom, .bottomLeft, .leftTop]
     }
+
+//    func reachablePositions() -> [Piece.Position] {
+//        let maximumReach = max(
+//            (File.H.rawValue) - position.file.rawValue,
+//            (Rank.eight.rawValue) - position.rank.rawValue,
+//            position.file.rawValue,
+//            position.rank.rawValue
+//        )
+//        
+//        var positions = [Piece.Position]()
+//        for step in 1...maximumReach {
+//            positions.append(contentsOf: getReachableDiagonalPostions(step: step))
+//        }
+//        return positions
+//    }
+//    
+//    func getReachableDiagonalPostions(step: Int) -> [Piece.Position] {
+//        var positions = [Piece.Position]()
+//        
+//        for i in [-1 * step, 1 * step] {
+//            for j in [-1 * step, +1 * step] {
+//                if let rank = position.rank.getPoint(added: i),
+//                   let file = position.file.getPoint(added: j) {
+//                    positions.append(Piece.Position(rank: rank, file: file))
+//                }
+//            }
+//        }
+//        
+//        return positions
+//    }
 
     func initializablePositions() -> [Piece.Position] {
         switch color {

--- a/ray-chess/ray-chess/Chess/Bishop.swift
+++ b/ray-chess/ray-chess/Chess/Bishop.swift
@@ -17,7 +17,6 @@ class Bishop: Piecable {
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color
         self.position = position
-        self.maxCount = 8
 
         switch color {
         case .white:

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -11,10 +11,10 @@ import Foundation
 // - 말 셋팅 관리
 // - 말 움직임 관리
 class Board {
-    var matrix: [[Piece?]]
+    private(set) var matrix: [[Piecable?]]
     
     init() {
-        let rank = Array<Piece?>(repeating: nil, count: 8)
+        let rank = Array<Piecable?>(repeating: nil, count: 8)
         self.matrix = Array(repeating: rank, count: 8)
     }
     
@@ -121,7 +121,7 @@ extension Board {
         guard !existSameColorPiece(from: from, to: to) else {
             return false
         }
-        guard isOneStepFoward(from: from, to: to, currentColor: currentColor) else {
+        guard isReachablePosition(from: from, to: to, currentColor: currentColor) else {
             return false
         }
         
@@ -129,7 +129,7 @@ extension Board {
     }
     
     func movePawn(from: Piece.Position, to: Piece.Position) {
-        let pawn = getPieceOnBoard(position: from)
+        var pawn = getPieceOnBoard(position: from)
         pawn?.position = to
         setPieceOnBoard(position: to, piece: pawn)
         
@@ -180,12 +180,12 @@ extension Board {
 
 // MARK: - Matrix Common
 extension Board {
-    func getPieceOnBoard(position: Piece.Position) -> Piece? {
+    func getPieceOnBoard(position: Piece.Position) -> Piecable? {
         return matrix[position.rank.rawValue][position.file.rawValue]
     }
     
     @discardableResult
-    func setPieceOnBoard(position: Piece.Position, piece: Piece?) -> Bool {
+    func setPieceOnBoard(position: Piece.Position, piece: Piecable?) -> Bool {
         matrix[position.rank.rawValue][position.file.rawValue] = piece
         return true
     }

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -11,10 +11,10 @@ import Foundation
 // - 말 셋팅 관리
 // - 말 움직임 관리
 class Board {
-    var matrix: [[String]]
+    var matrix: [[Piece?]]
     
     init() {
-        let rank = Array(repeating: ".", count: 8)
+        let rank = Array<Piece?>(repeating: nil, count: 8)
         self.matrix = Array(repeating: rank, count: 8)
     }
     
@@ -66,7 +66,7 @@ extension Board {
         // piece를 파라미터로 받는게 좋을까?
         let piece = getPieceOnBoard(position: position)
         
-        if piece == "." {
+        if piece == nil {
             return true
         } else {
             return false
@@ -91,7 +91,7 @@ extension Board {
         var num: Int = 0
         matrix.forEach { ranks in
             ranks.forEach { piece in
-                if piece == PawnConst.whiteName {
+                if piece?.color == .white {
                     num += 1
                 }
             }
@@ -103,7 +103,7 @@ extension Board {
         var num: Int = 0
         matrix.forEach { ranks in
             ranks.forEach { piece in
-                if piece == PawnConst.blackName {
+                if piece?.color == .black {
                     num += 1
                 }
             }
@@ -128,9 +128,12 @@ extension Board {
         return true
     }
     
-    func movePawn(from: Piece.Position, to: Piece.Position, pieceName: String) {
-        setPieceOnBoard(position: from, name: ".")
-        setPieceOnBoard(position: to, name: pieceName)
+    func movePawn(from: Piece.Position, to: Piece.Position) {
+        let pawn = getPieceOnBoard(position: from)
+        pawn?.position = to
+        setPieceOnBoard(position: to, piece: pawn)
+        
+        setPieceOnBoard(position: from, piece: nil)
     }
     
     func isMyPiece(from: Piece.Position, currentColor: Piece.Color) -> Bool {
@@ -138,7 +141,7 @@ extension Board {
             return false
         }
         
-        if fromPiece.suffix(1) == currentColor.getSymbolString() {
+        if fromPiece.color == currentColor {
             return true
         } else {
             return false
@@ -149,7 +152,7 @@ extension Board {
         let fromPiece = getPieceOnBoard(position: from)
         let toPiece = getPieceOnBoard(position: to)
         
-        if toPiece?.suffix(1) == fromPiece?.suffix(1) {
+        if fromPiece?.color == toPiece?.color {
             return true
         } else {
             return false
@@ -177,13 +180,13 @@ extension Board {
 
 // MARK: - Matrix Common
 extension Board {
-    func getPieceOnBoard(position: Piece.Position) -> String? {
+    func getPieceOnBoard(position: Piece.Position) -> Piece? {
         return matrix[position.rank.rawValue][position.file.rawValue]
     }
     
     @discardableResult
-    func setPieceOnBoard(position: Piece.Position, name: String) -> Bool {
-        matrix[position.rank.rawValue][position.file.rawValue] = name
+    func setPieceOnBoard(position: Piece.Position, piece: Piece?) -> Bool {
+        matrix[position.rank.rawValue][position.file.rawValue] = piece
         return true
     }
 }

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -80,7 +80,7 @@ extension Board {
     }
     
     func isCorrectRankPosition(piece: Piecable) -> Bool {
-        return piece.isInitializableRank()
+        return piece.initializablePositions().contains(piece.position)
     }
     
     func IsEmptyPosition(position: Piece.Position) -> Bool {

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -65,14 +65,14 @@ class Board {
 
 // MARK: - Pawn initialize
 extension Board {
-    func canSetPawn(pawn: Pawn) -> Result<Bool, Board.SetError> {
-        guard isCorrectRankPosition(piece: pawn) else {
+    func canSetPiece(piece: Piecable) -> Result<Bool, Board.SetError> {
+        guard isCorrectRankPosition(piece: piece) else {
             return .failure(.wrongInitRank)
         }
-        guard IsEmptyPosition(position: pawn.position) else {
+        guard IsEmptyPosition(position: piece.position) else {
             return .failure(.isFulledPosition)
         }
-        guard !IsOverPieceMaxCount(piece: pawn) else {
+        guard !IsOverPieceMaxCount(piece: piece) else {
             return .failure(.isOverMaxCount)
         }
         
@@ -111,7 +111,7 @@ extension Board {
 
 // MARK: - Pawn move
 extension Board {
-    func canMovePawn(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Result<Bool, Board.MoveError> {
+    func canMovePiece(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Result<Bool, Board.MoveError> {
         guard let targetPiece = getPieceOnBoard(position: from) else {
             return .failure(.isEmptySpace)
         }

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -91,7 +91,6 @@ extension Board {
     
     func IsOverPieceMaxCount(piece: Piecable) -> Bool {
         let numberOfPiece = theNumberOf(targetPiece: piece)
-        
         return numberOfPiece >= piece.maxCount
     }
     
@@ -100,7 +99,7 @@ extension Board {
         matrix.forEach { ranks in
             ranks.forEach { piece in
                 if piece?.color == targetPiece.color
-                    || piece?.name == targetPiece.name {
+                    && piece?.name == targetPiece.name {
                     num += 1
                 }
             }
@@ -118,7 +117,7 @@ extension Board {
         guard isMyPiece(targetPiece: targetPiece, currentColor: currentColor) else {
             return .failure(.isNotMyPiece)
         }
-        guard !existSameColorPiece(targetPiece: targetPiece, to: to) else {
+        guard !isBlockedByMyPiece(targetPiece: targetPiece, to: to) else {
             return .failure(.existSameColorPiece)
         }
         guard isReachablePosition(targetPiece: targetPiece, to: to) else {
@@ -140,7 +139,7 @@ extension Board {
         return targetPiece.color == currentColor
     }
     
-    func existSameColorPiece(targetPiece: Piecable, to: Piece.Position) -> Bool {
+    func isBlockedByMyPiece(targetPiece: Piecable, to: Piece.Position) -> Bool {
         let toPiece = getPieceOnBoard(position: to)
         
         return targetPiece.color == toPiece?.color

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -146,7 +146,41 @@ extension Board {
     }
     
     func isReachablePosition(targetPiece: Piecable, to: Piece.Position) -> Bool {
-        return targetPiece.reachablePositions().contains(to)
+        let reachablePositions = self.getReachablePositions(targetPiece: targetPiece)
+        return reachablePositions.contains(to)
+    }
+    
+    func getReachablePositions(targetPiece: Piecable) -> [Piece.Position] {
+        switch targetPiece.moveType {
+        case .line:
+            var directions = targetPiece.reachableDirections().map { $0.getRawValue() }
+            var positions = [Piece.Position]()
+            
+            for step in 1...targetPiece.getMaximumStep() {
+                directions = directions.compactMap { direction in
+                    let directionMutiplied = (file: direction.file * step, rank: direction.rank * step)
+                    
+                    guard let rank = targetPiece.position.rank.getPoint(added: directionMutiplied.rank),
+                          let file = targetPiece.position.file.getPoint(added: directionMutiplied.file) else {
+                        return nil
+                    }
+                        
+                    if isBlockedByMyPiece(targetPiece: targetPiece, to: .init(rank: rank, file: file)) {
+                        return nil
+                    } else {
+                        positions.append(Piece.Position(rank: rank, file: file))
+                        return direction
+                    }
+                }
+            }
+            return positions
+                    
+        case .dot:
+            let positions = targetPiece.reachablePositions().filter { position in
+                return !isBlockedByMyPiece(targetPiece: targetPiece, to: position)
+            }
+            return positions
+        }
     }
 }
 

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -50,7 +50,6 @@ extension Board {
     }
     
     func IsEmptyPosition(position: Piece.Position) -> Bool {
-        // piece를 파라미터로 받는게 좋을까?
         let piece = getPieceOnBoard(position: position)
         
         if piece == nil {

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -92,7 +92,7 @@ extension Board {
     func IsOverPieceMaxCount(piece: Piecable) -> Bool {
         let numberOfPiece = theNumberOf(targetPiece: piece)
         
-        return numberOfPiece > piece.maxCount
+        return numberOfPiece >= piece.maxCount
     }
     
     func theNumberOf(targetPiece: Piecable) -> Int {

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -65,7 +65,7 @@ extension Board {
         return false
     }
     
-    func IsEmptyPosition(position: PiecePosition) -> Bool {
+    func IsEmptyPosition(position: Piece.Position) -> Bool {
         // piece를 파라미터로 받는게 좋을까?
         let piece = getPieceOnBoard(rank: position.rank, file: position.file)
         
@@ -76,7 +76,7 @@ extension Board {
         }
     }
     
-    func IsOverPawnMaxCount(color: PieceColor) -> Bool {
+    func IsOverPawnMaxCount(color: Piece.Color) -> Bool {
         switch color {
         case .white:
             if theNumberOfWhitePawn() > PawnConst.maxCount {
@@ -117,7 +117,7 @@ extension Board {
 
 // MARK: - Pawn move
 extension Board {
-    func canMovePawn(from: PiecePosition, to: PiecePosition, currentColor: PieceColor) -> Bool {
+    func canMovePawn(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Bool {
         guard !indexOutOfRange(rank: to.rank, file: to.file) else {
             return false
         }
@@ -134,12 +134,12 @@ extension Board {
         return true
     }
     
-    func movePawn(from: PiecePosition, to: PiecePosition, pieceName: String) {
+    func movePawn(from: Piece.Position, to: Piece.Position, pieceName: String) {
         setPieceOnBoard(position: from, name: ".")
         setPieceOnBoard(position: to, name: pieceName)
     }
     
-    func isMyPiece(from: PiecePosition, currentColor: PieceColor) -> Bool {
+    func isMyPiece(from: Piece.Position, currentColor: Piece.Color) -> Bool {
         guard let fromPiece = getPieceOnBoard(rank: from.rank, file: from.file) else {
             return false
         }
@@ -151,7 +151,7 @@ extension Board {
         }
     }
     
-    func existSameColorPiece(from: PiecePosition, to: PiecePosition) -> Bool {
+    func existSameColorPiece(from: Piece.Position, to: Piece.Position) -> Bool {
         let fromPiece = getPieceOnBoard(rank: from.rank, file: from.file)
         let toPiece = getPieceOnBoard(rank: to.rank, file: to.file)
         
@@ -162,7 +162,7 @@ extension Board {
         }
     }
     
-    func isOneStepFoward(from: PiecePosition, to: PiecePosition, currentColor: PieceColor) -> Bool {
+    func isOneStepFoward(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Bool {
         if from.file == to.file {
             switch currentColor {
             case .white:
@@ -191,7 +191,7 @@ extension Board {
     }
     
     @discardableResult
-    func setPieceOnBoard(position: PiecePosition, name: String) -> Bool {
+    func setPieceOnBoard(position: Piece.Position, name: String) -> Bool {
         let rank = position.rank
         let file = position.file
         guard rank >= 1 && rank <= 8 && file >= 1 && file <= 8 else {

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -18,13 +18,33 @@ class Board {
         self.matrix = Array(repeating: rank, count: 8)
     }
     
-    func showScore() {
-        //
+    func getScore() -> (black: Int, white: Int) {
+        var blackScore = 0
+        var whiteScore = 0
+
+        matrix.forEach { rank in
+            rank.forEach { piece in
+                if piece?.color == .white {
+                    whiteScore += 1
+                }
+                if piece?.color == .black {
+                    blackScore += 1
+                }
+            }
+        }
+        
+        return (blackScore, whiteScore)
     }
     
-    func display() {
-        matrix.forEach { rank in
-            print(rank)
+    func display() -> [[String]] {
+        matrix.map { rank -> [String] in
+            let formattedRank = rank.map { piece -> String in
+                guard let piece = piece else {
+                    return "."
+                }
+                return piece.getSymbol()
+            }
+            return formattedRank
         }
     }
     

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -147,7 +147,7 @@ extension Board {
     }
     
     func isReachablePosition(targetPiece: Piecable, to: Piece.Position) -> Bool {
-        return targetPiece.reachablePosition().contains(to)
+        return targetPiece.reachablePositions().contains(to)
     }
 }
 

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -27,22 +27,29 @@ class Board {
             print(rank)
         }
     }
+    
+    enum ErrorCase: Error {
+        case isEmptySpace
+        case wrongInitRank
+        case isFulledPosition
+        case isOverMaxCount
+    }
 }
 
 // MARK: - Pawn initialize
 extension Board {
-    func canSetPawn(pawn: Pawn) -> Bool {
+    func canSetPawn(pawn: Pawn) -> Result<Bool, Board.ErrorCase> {
         guard isCorrectRankPosition(piece: pawn) else {
-            return false
+            return .failure(.wrongInitRank)
         }
         guard IsEmptyPosition(position: pawn.position) else {
-            return false
+            return .failure(.isFulledPosition)
         }
         guard !IsOverPieceMaxCount(piece: pawn) else {
-            return false
+            return .failure(.isOverMaxCount)
         }
         
-        return true
+        return .success(true)
     }
     
     func isCorrectRankPosition(piece: Piecable) -> Bool {
@@ -52,11 +59,7 @@ extension Board {
     func IsEmptyPosition(position: Piece.Position) -> Bool {
         let piece = getPieceOnBoard(position: position)
         
-        if piece == nil {
-            return true
-        } else {
-            return false
-        }
+        return piece == nil
     }
     
     func IsOverPieceMaxCount(piece: Piecable) -> Bool {

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -32,9 +32,6 @@ class Board {
 // MARK: - Pawn initialize
 extension Board {
     func canSetPawn(pawn: Pawn) -> Bool {
-        guard !indexOutOfRange(rank: pawn.position.rank, file: pawn.position.file) else {
-            return false
-        }
         guard isCorrectRankPosition(piece: pawn) else {
             return false
         }
@@ -53,11 +50,11 @@ extension Board {
         
         switch piece.getColor() {
         case .white:
-            if rank == 7 || rank == 8 {
+            if rank == .seven || rank == .eight {
                 return true
             }
         case .black:
-            if rank == 1 || rank == 2 {
+            if rank == .one || rank == .two {
                 return true
             }
         }
@@ -67,7 +64,7 @@ extension Board {
     
     func IsEmptyPosition(position: Piece.Position) -> Bool {
         // piece를 파라미터로 받는게 좋을까?
-        let piece = getPieceOnBoard(rank: position.rank, file: position.file)
+        let piece = getPieceOnBoard(position: position)
         
         if piece == "." {
             return true
@@ -118,9 +115,6 @@ extension Board {
 // MARK: - Pawn move
 extension Board {
     func canMovePawn(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Bool {
-        guard !indexOutOfRange(rank: to.rank, file: to.file) else {
-            return false
-        }
         guard isMyPiece(from: from, currentColor: currentColor) else {
             return false
         }
@@ -140,7 +134,7 @@ extension Board {
     }
     
     func isMyPiece(from: Piece.Position, currentColor: Piece.Color) -> Bool {
-        guard let fromPiece = getPieceOnBoard(rank: from.rank, file: from.file) else {
+        guard let fromPiece = getPieceOnBoard(position: from) else {
             return false
         }
         
@@ -152,8 +146,8 @@ extension Board {
     }
     
     func existSameColorPiece(from: Piece.Position, to: Piece.Position) -> Bool {
-        let fromPiece = getPieceOnBoard(rank: from.rank, file: from.file)
-        let toPiece = getPieceOnBoard(rank: to.rank, file: to.file)
+        let fromPiece = getPieceOnBoard(position: from)
+        let toPiece = getPieceOnBoard(position: to)
         
         if toPiece?.suffix(1) == fromPiece?.suffix(1) {
             return true
@@ -166,11 +160,11 @@ extension Board {
         if from.file == to.file {
             switch currentColor {
             case .white:
-                if (to.rank - from.rank) == -1 {
+                if (to.rank.rawValue - from.rank.rawValue) == -1 {
                     return true
                 }
             case .black:
-                if (to.rank - from.rank) == 1 {
+                if (to.rank.rawValue - from.rank.rawValue) == 1 {
                     return true
                 }
             }
@@ -183,29 +177,13 @@ extension Board {
 
 // MARK: - Matrix Common
 extension Board {
-    func getPieceOnBoard(rank: Int, file: Int) -> String? {
-        guard rank >= 1 && rank <= 8 && file >= 1 && file <= 8 else {
-            return nil
-        }
-        return matrix[rank - 1][file - 1]
+    func getPieceOnBoard(position: Piece.Position) -> String? {
+        return matrix[position.rank.rawValue][position.file.rawValue]
     }
     
     @discardableResult
     func setPieceOnBoard(position: Piece.Position, name: String) -> Bool {
-        let rank = position.rank
-        let file = position.file
-        guard rank >= 1 && rank <= 8 && file >= 1 && file <= 8 else {
-            return false
-        }
-        
-        matrix[rank - 1][file - 1] = name
+        matrix[position.rank.rawValue][position.file.rawValue] = name
         return true
-    }
-    
-    func indexOutOfRange(rank: Int, file: Int) -> Bool {
-        if rank < 1 || rank > 8 || file < 1 || file > 8 {
-            return true
-        }
-        return false
     }
 }

--- a/ray-chess/ray-chess/Chess/Board.swift
+++ b/ray-chess/ray-chess/Chess/Board.swift
@@ -38,28 +38,15 @@ extension Board {
         guard IsEmptyPosition(position: pawn.position) else {
             return false
         }
-        guard !IsOverPawnMaxCount(color: pawn.color) else {
+        guard !IsOverPieceMaxCount(piece: pawn) else {
             return false
         }
         
         return true
     }
     
-    func isCorrectRankPosition(piece: Piece) -> Bool {
-        let rank = piece.position.rank
-        
-        switch piece.getColor() {
-        case .white:
-            if rank == .seven || rank == .eight {
-                return true
-            }
-        case .black:
-            if rank == .one || rank == .two {
-                return true
-            }
-        }
-        
-        return false
+    func isCorrectRankPosition(piece: Piecable) -> Bool {
+        return piece.isInitializableRank()
     }
     
     func IsEmptyPosition(position: Piece.Position) -> Bool {
@@ -73,37 +60,18 @@ extension Board {
         }
     }
     
-    func IsOverPawnMaxCount(color: Piece.Color) -> Bool {
-        switch color {
-        case .white:
-            if theNumberOfWhitePawn() > PawnConst.maxCount {
-                return true
-            }
-        case .black:
-            if theNumberOfBlackPawn() > PawnConst.maxCount {
-                return true
-            }
-        }
-        return false
+    func IsOverPieceMaxCount(piece: Piecable) -> Bool {
+        let numberOfPiece = theNumberOf(targetPiece: piece)
+        
+        return numberOfPiece > piece.maxCount
     }
     
-    func theNumberOfWhitePawn() -> Int {
+    func theNumberOf(targetPiece: Piecable) -> Int {
         var num: Int = 0
         matrix.forEach { ranks in
             ranks.forEach { piece in
-                if piece?.color == .white {
-                    num += 1
-                }
-            }
-        }
-        return num
-    }
-    
-    func theNumberOfBlackPawn() -> Int {
-        var num: Int = 0
-        matrix.forEach { ranks in
-            ranks.forEach { piece in
-                if piece?.color == .black {
+                if piece?.color == targetPiece.color
+                    || piece?.name == targetPiece.name {
                     num += 1
                 }
             }
@@ -141,39 +109,22 @@ extension Board {
             return false
         }
         
-        if fromPiece.color == currentColor {
-            return true
-        } else {
-            return false
-        }
+        return fromPiece.color == currentColor
     }
     
     func existSameColorPiece(from: Piece.Position, to: Piece.Position) -> Bool {
         let fromPiece = getPieceOnBoard(position: from)
         let toPiece = getPieceOnBoard(position: to)
         
-        if fromPiece?.color == toPiece?.color {
-            return true
-        } else {
-            return false
-        }
+        return fromPiece?.color == toPiece?.color
     }
     
-    func isOneStepFoward(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Bool {
-        if from.file == to.file {
-            switch currentColor {
-            case .white:
-                if (to.rank.rawValue - from.rank.rawValue) == -1 {
-                    return true
-                }
-            case .black:
-                if (to.rank.rawValue - from.rank.rawValue) == 1 {
-                    return true
-                }
-            }
+    func isReachablePosition(from: Piece.Position, to: Piece.Position, currentColor: Piece.Color) -> Bool {
+        guard let piece = getPieceOnBoard(position: from) else {
+            return false
         }
         
-        return false
+        return piece.reachablePosition().contains(to)
     }
 }
 

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -30,6 +30,8 @@ class ChessGame {
         initializePawn()
         initializeBishop()
         initializeRook()
+        initializeQueen()
+        initializeKnight()
     }
     
     func initializePawn() {
@@ -51,6 +53,22 @@ class ChessGame {
         [
             Queen(color: .white, position: .init(rank: .eight, file: .E)),
             Queen(color: .black, position: .init(rank: .one, file: .E))
+        ].forEach { rook in
+            switch board.canSetPiece(piece: rook) {
+            case .success(_):
+                board.setPieceOnBoard(position: rook.position, piece: rook)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func initializeKnight() {
+        [
+            Knight(color: .white, position: .init(rank: .eight, file: .B)),
+            Knight(color: .white, position: .init(rank: .eight, file: .G)),
+            Knight(color: .black, position: .init(rank: .one, file: .B)),
+            Knight(color: .black, position: .init(rank: .one, file: .G)),
         ].forEach { rook in
             switch board.canSetPiece(piece: rook) {
             case .success(_):

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -22,7 +22,7 @@ class ChessGame {
         File.allCases.forEach { file in
             let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: file))
             
-            switch board.canSetPawn(pawn: pawn) {
+            switch board.canSetPiece(piece: pawn) {
             case .success(_):
                 board.setPieceOnBoard(position: pawn.position, piece: pawn)
             case .failure(let error):
@@ -35,7 +35,7 @@ class ChessGame {
         File.allCases.forEach { file in
             let pawn = Pawn(color: .white, position: Piece.Position(rank: .seven, file: file))
             
-            switch board.canSetPawn(pawn: pawn) {
+            switch board.canSetPiece(piece: pawn) {
             case .success(_):
                 board.setPieceOnBoard(position: pawn.position, piece: pawn)
             case .failure(let error):

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -22,8 +22,11 @@ class ChessGame {
         File.allCases.forEach { file in
             let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: file))
             
-            if board.canSetPawn(pawn: pawn) {
+            switch board.canSetPawn(pawn: pawn) {
+            case .success(_):
                 board.setPieceOnBoard(position: pawn.position, piece: pawn)
+            case .failure(let error):
+                print(error)
             }
         }
     }
@@ -32,8 +35,11 @@ class ChessGame {
         File.allCases.forEach { file in
             let pawn = Pawn(color: .white, position: Piece.Position(rank: .seven, file: file))
             
-            if board.canSetPawn(pawn: pawn) {
+            switch board.canSetPawn(pawn: pawn) {
+            case .success(_):
                 board.setPieceOnBoard(position: pawn.position, piece: pawn)
+            case .failure(let error):
+                print(error)
             }
         }
     }

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -23,7 +23,7 @@ class ChessGame {
             let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: file))
             
             if board.canSetPawn(pawn: pawn) {
-                board.setPieceOnBoard(position: pawn.position, name: pawn.name)
+                board.setPieceOnBoard(position: pawn.position, piece: pawn)
             }
         }
     }
@@ -33,7 +33,7 @@ class ChessGame {
             let pawn = Pawn(color: .white, position: Piece.Position(rank: .seven, file: file))
             
             if board.canSetPawn(pawn: pawn) {
-                board.setPieceOnBoard(position: pawn.position, name: pawn.name)
+                board.setPieceOnBoard(position: pawn.position, piece: pawn)
             }
         }
     }

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -19,8 +19,8 @@ class ChessGame {
     }
     
     func initBlackPawn() {
-        for file in 1...PawnConst.maxCount {
-            let pawn = Pawn(color: .black, position: Piece.Position(rank: PawnConst.blackStartRank, file: file))
+        File.allCases.forEach { file in
+            let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: file))
             
             if board.canSetPawn(pawn: pawn) {
                 board.setPieceOnBoard(position: pawn.position, name: pawn.name)
@@ -29,8 +29,8 @@ class ChessGame {
     }
     
     func initWhitePawn() {
-        for file in 1...PawnConst.maxCount {
-            let pawn = Pawn(color: .white, position: Piece.Position(rank: PawnConst.whiteStartRank, file: file))
+        File.allCases.forEach { file in
+            let pawn = Pawn(color: .white, position: Piece.Position(rank: .seven, file: file))
             
             if board.canSetPawn(pawn: pawn) {
                 board.setPieceOnBoard(position: pawn.position, name: pawn.name)

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -47,6 +47,20 @@ class ChessGame {
         initWhiteRook()
     }
     
+    func initializeQueen() {
+        [
+            Queen(color: .white, position: .init(rank: .eight, file: .E)),
+            Queen(color: .black, position: .init(rank: .one, file: .E))
+        ].forEach { rook in
+            switch board.canSetPiece(piece: rook) {
+            case .success(_):
+                board.setPieceOnBoard(position: rook.position, piece: rook)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
     func initBlackPawn() {
         File.allCases.forEach { file in
             let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: file))

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -20,7 +20,7 @@ class ChessGame {
     
     func initBlackPawn() {
         for file in 1...PawnConst.maxCount {
-            let pawn = Pawn(color: .black, position: PiecePosition(rank: PawnConst.blackStartRank, file: file))
+            let pawn = Pawn(color: .black, position: Piece.Position(rank: PawnConst.blackStartRank, file: file))
             
             if board.canSetPawn(pawn: pawn) {
                 board.setPieceOnBoard(position: pawn.position, name: pawn.name)
@@ -30,7 +30,7 @@ class ChessGame {
     
     func initWhitePawn() {
         for file in 1...PawnConst.maxCount {
-            let pawn = Pawn(color: .white, position: PiecePosition(rank: PawnConst.whiteStartRank, file: file))
+            let pawn = Pawn(color: .white, position: Piece.Position(rank: PawnConst.whiteStartRank, file: file))
             
             if board.canSetPawn(pawn: pawn) {
                 board.setPieceOnBoard(position: pawn.position, name: pawn.name)

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -21,22 +21,7 @@ class ChessGame {
         guard let piece = board.getPieceOnBoard(position: position) else {
             return []
         }
-        let reachablePositions = piece.reachablePositions()
-        let possiblePositions = reachablePositions
-            .filter { position in
-                let canMove = board.canMovePiece(
-                    from: piece.position,
-                    to: position,
-                    currentColor: piece.color
-                )
-                
-                switch canMove {
-                case .success(_):
-                    return true
-                case .failure(let error):
-                    return false
-                }
-            }
+        let possiblePositions = board.getReachablePositions(targetPiece: piece)
         
         return possiblePositions
     }

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -17,6 +17,30 @@ class ChessGame {
         
     }
     
+    func possibleToMove(position: Piece.Position) -> [Piece.Position] {
+        guard let piece = board.getPieceOnBoard(position: position) else {
+            return []
+        }
+        let reachablePositions = piece.reachablePositions()
+        let possiblePositions = reachablePositions
+            .filter { position in
+                let canMove = board.canMovePiece(
+                    from: piece.position,
+                    to: position,
+                    currentColor: piece.color
+                )
+                
+                switch canMove {
+                case .success(_):
+                    return true
+                case .failure(let error):
+                    return false
+                }
+            }
+        
+        return possiblePositions
+    }
+    
     func initializePieces() {
         initializePawn()
         initializeBishop()

--- a/ray-chess/ray-chess/Chess/ChessGame.swift
+++ b/ray-chess/ray-chess/Chess/ChessGame.swift
@@ -14,8 +14,28 @@ class ChessGame {
     let board = Board()
     
     init() {
-        self.initBlackPawn()
-        self.initWhitePawn()
+        
+    }
+    
+    func initializePieces() {
+        initializePawn()
+        initializeBishop()
+        initializeRook()
+    }
+    
+    func initializePawn() {
+        initBlackPawn()
+        initWhitePawn()
+    }
+    
+    func initializeBishop() {
+        initBlackBishop()
+        initWhiteBishop()
+    }
+    
+    func initializeRook() {
+        initBlackRook()
+        initWhiteRook()
     }
     
     func initBlackPawn() {
@@ -44,4 +64,59 @@ class ChessGame {
         }
     }
     
+    func initBlackBishop() {
+        [
+            Bishop(color: .black, position: .init(rank: .one, file: .C)),
+            Bishop(color: .black, position: .init(rank: .one, file: .F))
+        ].forEach { bishop in
+            switch board.canSetPiece(piece: bishop) {
+            case .success(_):
+                board.setPieceOnBoard(position: bishop.position, piece: bishop)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func initWhiteBishop() {
+        [
+            Bishop(color: .white, position: .init(rank: .eight, file: .C)),
+            Bishop(color: .white, position: .init(rank: .eight, file: .F))
+        ].forEach { bishop in
+            switch board.canSetPiece(piece: bishop) {
+            case .success(_):
+                board.setPieceOnBoard(position: bishop.position, piece: bishop)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func initBlackRook() {
+        [
+            Rook(color: .black, position: .init(rank: .one, file: .A)),
+            Rook(color: .black, position: .init(rank: .one, file: .H))
+        ].forEach { rook in
+            switch board.canSetPiece(piece: rook) {
+            case .success(_):
+                board.setPieceOnBoard(position: rook.position, piece: rook)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
+    
+    func initWhiteRook() {
+        [
+            Rook(color: .white, position: .init(rank: .eight, file: .A)),
+            Rook(color: .white, position: .init(rank: .eight, file: .H))
+        ].forEach { rook in
+            switch board.canSetPiece(piece: rook) {
+            case .success(_):
+                board.setPieceOnBoard(position: rook.position, piece: rook)
+            case .failure(let error):
+                print(error)
+            }
+        }
+    }
 }

--- a/ray-chess/ray-chess/Chess/Knight.swift
+++ b/ray-chess/ray-chess/Chess/Knight.swift
@@ -1,0 +1,60 @@
+//
+//  Knight.swift
+//  ray-chess
+//
+//  Created by 김상진 on 2022/10/03.
+//
+
+import Foundation
+
+class Knight: Piecable {
+    var position: Piece.Position
+    var color: Piece.Color
+    var name: String
+    var maxCount: Int = 2
+    var moveType: Piece.MoveType = .dot
+    
+    init(color: Piece.Color, position: Piece.Position) {
+        self.color = color
+        self.position = position
+        
+        switch color {
+        case .white:
+            self.name = "U+2658"
+        case .black:
+            self.name = "U+265E"
+        }
+    }
+    
+    func initializablePositions() -> [Piece.Position] {
+        switch color {
+        case .black:
+            return [Piece.Position(rank: .one, file: .B), Piece.Position(rank: .one, file: .G)]
+        case .white:
+            return [Piece.Position(rank: .eight, file: .B), Piece.Position(rank: .eight, file: .G)]
+        }
+    }
+    
+    func reachablePositions() -> [Piece.Position] {
+        var positions = [Piece.Position]()
+        [(2,-1), (2,1), (-2,-1), (-2,1), (1,-2), (-1,-2), (1,2), (-1,2)]
+            .forEach { (file: Int, rank: Int) in
+            if let rank = position.rank.getPoint(added: rank),
+               let file = position.file.getPoint(added: file) {
+                positions.append(.init(rank: rank, file: file))
+            }
+        }
+        return positions
+    }
+    
+    func getSymbol() -> String {
+        switch color {
+        case .white:
+            return "♘"
+        case .black:
+            return "♞"
+        }
+    }
+    
+    
+}

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -12,6 +12,7 @@ class Pawn: Piecable {
     var color: Piece.Color
     var name: String
     var maxCount: Int
+    var moveType: Piece.MoveType = .dot
     
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -20,9 +20,9 @@ class Pawn: Piecable {
         
         switch color {
         case .white:
-            self.name = "U+2569"
+            self.name = "U+2659"
         case .black:
-            self.name = "U+256F"
+            self.name = "U+265F"
         }
     }
     
@@ -41,15 +41,20 @@ class Pawn: Piecable {
         }
     }
     
-    func isInitializableRank() -> Bool {
-        let rank = self.position.rank
+    func initializablePositions() -> [Piece.Position] {
+        var positions = [Piece.Position]()
         
         switch color {
         case .white:
-            return rank == .seven
+            File.allCases.forEach { file in
+                positions.append(Piece.Position(rank: .seven, file: file))
+            }
         case .black:
-            return rank == .two
+            File.allCases.forEach { file in
+                positions.append(Piece.Position(rank: .two, file: file))
+            }
         }
+        return positions
     }
     
     func getSymbol() -> String {

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -9,7 +9,7 @@ import Foundation
 
 class Pawn: Piece {
     
-    init(color: PieceColor, position: PiecePosition) {
+    init(color: Piece.Color, position: Piece.Position) {
         switch color {
         case .white:
             super.init(color: color, position: position, name: PawnConst.whiteName)

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -11,10 +11,12 @@ class Pawn: Piecable {
     var position: Piece.Position
     var color: Piece.Color
     var name: String
+    var maxCount: Int
     
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color
         self.position = position
+        self.maxCount = 8
         
         switch color {
         case .white:

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -20,9 +20,9 @@ class Pawn: Piecable {
         
         switch color {
         case .white:
-            self.name = PawnConst.whiteName
+            self.name = "U+2569"
         case .black:
-            self.name = PawnConst.blackName
+            self.name = "U+256F"
         }
     }
     
@@ -40,13 +40,16 @@ class Pawn: Piecable {
             return [Piece.Position(rank: newRank, file: self.position.file)]
         }
     }
-}
-
-struct PawnConst {
-    static let maxCount: Int = 8
-    static let whiteStartRank: Int = 7
-    static let blackStartRank: Int = 2
-    static let blackName = "U+256F"
-    static let whiteName = "U+2569"
+    
+    func isInitializableRank() -> Bool {
+        let rank = self.position.rank
+        
+        switch color {
+        case .white:
+            return rank == .seven
+        case .black:
+            return rank == .two
+        }
+    }
 }
 

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -7,14 +7,35 @@
 
 import Foundation
 
-class Pawn: Piece {
+class Pawn: Piecable {
+    var position: Piece.Position
+    var color: Piece.Color
+    var name: String
     
     init(color: Piece.Color, position: Piece.Position) {
+        self.color = color
+        self.position = position
+        
         switch color {
         case .white:
-            super.init(color: color, position: position, name: PawnConst.whiteName)
+            self.name = PawnConst.whiteName
         case .black:
-            super.init(color: color, position: position, name: PawnConst.blackName)
+            self.name = PawnConst.blackName
+        }
+    }
+    
+    func reachablePosition() -> [Piece.Position] {
+        switch color {
+        case .white:
+            guard let newRank = self.position.rank.getPoint(added: -1) else {
+                return []
+            }
+            return [Piece.Position(rank: newRank, file: self.position.file)]
+        case .black:
+            guard let newRank = self.position.rank.getPoint(added: 1) else {
+                return []
+            }
+            return [Piece.Position(rank: newRank, file: self.position.file)]
         }
     }
 }

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -26,7 +26,7 @@ class Pawn: Piecable {
         }
     }
     
-    func reachablePosition() -> [Piece.Position] {
+    func reachablePositions() -> [Piece.Position] {
         switch color {
         case .white:
             guard let newRank = self.position.rank.getPoint(added: -1) else {

--- a/ray-chess/ray-chess/Chess/Pawn.swift
+++ b/ray-chess/ray-chess/Chess/Pawn.swift
@@ -51,5 +51,14 @@ class Pawn: Piecable {
             return rank == .two
         }
     }
+    
+    func getSymbol() -> String {
+        switch color {
+        case .white:
+            return "♙"
+        case .black:
+            return "♟"
+        }
+    }
 }
 

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -11,7 +11,22 @@ protocol Piecable {
     var position: Piece.Position { get set }
     var color: Piece.Color { get set }
     var name: String { get set }
+    var maxCount: Int { get set }
     func reachablePosition() -> [Piece.Position]
+    func isInitializableRank() -> Bool
+}
+
+extension Piecable {
+    func isInitializableRank() -> Bool {
+        let rank = self.position.rank
+        
+        switch color {
+        case .white:
+            return rank == .seven || rank == .eight
+        case .black:
+            return rank == .one || rank == .two
+        }
+    }
 }
 
 enum Piece {

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -14,6 +14,7 @@ protocol Piecable {
     var maxCount: Int { get set }
     func reachablePosition() -> [Piece.Position]
     func isInitializableRank() -> Bool
+    func getSymbol() -> String
 }
 
 enum Piece {

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -7,26 +7,15 @@
 
 import Foundation
 
-class Piece {
-    var position: Piece.Position
-    var color: Piece.Color
-    var name: String
-    
-    init(color: Piece.Color, position: Piece.Position, name: String) {
-        self.color = color
-        self.position = position
-        self.name = name
-    }
-    
-    func getColor() -> Piece.Color {
-        return self.color
-    }
-    
-    func getPosition() -> Piece.Position {
-        return self.position
-    }
-    
-    struct Position {
+protocol Piecable {
+    var position: Piece.Position { get set }
+    var color: Piece.Color { get set }
+    var name: String { get set }
+    func reachablePosition() -> [Piece.Position]
+}
+
+enum Piece {
+    struct Position: Equatable {
         var rank: Rank
         var file: File
     }
@@ -34,22 +23,23 @@ class Piece {
     enum Color {
         case white
         case black
-        
-        func getSymbolString() -> String {
-            switch self {
-            case .white:
-                return "9"
-            case .black:
-                return "F"
-            }
-        }
     }
 }
 
 enum File: Int, CaseIterable {
     case A = 0, B, C, D, E, F, G, H
+    
+    func getPoint(added: Int) -> File? {
+        let file = self.rawValue + added
+        return File(rawValue: file)
+    }
 }
 
 enum Rank: Int, CaseIterable {
     case one = 0, two, three, four, five, six, seven, eight
+    
+    func getPoint(added: Int) -> Rank? {
+        let rank = self.rawValue + added
+        return Rank(rawValue: rank)
+    }
 }

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -56,7 +56,7 @@ enum Piece {
         case dot
     }
     
-    enum Direction {
+    enum Direction: CaseIterable {
         case top
         case topRight
         case right

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -16,19 +16,6 @@ protocol Piecable {
     func isInitializableRank() -> Bool
 }
 
-extension Piecable {
-    func isInitializableRank() -> Bool {
-        let rank = self.position.rank
-        
-        switch color {
-        case .white:
-            return rank == .seven || rank == .eight
-        case .black:
-            return rank == .one || rank == .two
-        }
-    }
-}
-
 enum Piece {
     struct Position: Equatable {
         var rank: Rank

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -12,7 +12,7 @@ protocol Piecable {
     var color: Piece.Color { get set }
     var name: String { get set }
     var maxCount: Int { get set }
-    func reachablePosition() -> [Piece.Position]
+    func reachablePositions() -> [Piece.Position]
     func initializablePositions() -> [Piece.Position]
     func getSymbol() -> String
 }

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -13,7 +13,7 @@ protocol Piecable {
     var name: String { get set }
     var maxCount: Int { get set }
     func reachablePosition() -> [Piece.Position]
-    func isInitializableRank() -> Bool
+    func initializablePositions() -> [Piece.Position]
     func getSymbol() -> String
 }
 

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -12,9 +12,32 @@ protocol Piecable {
     var color: Piece.Color { get set }
     var name: String { get set }
     var maxCount: Int { get set }
+    var moveType: Piece.MoveType { get set }
+    
+    func reachableDirections() -> [Piece.Direction]
     func reachablePositions() -> [Piece.Position]
     func initializablePositions() -> [Piece.Position]
     func getSymbol() -> String
+    func getMaximumStep() -> Int
+}
+
+extension Piecable {
+    func reachableDirections() -> [Piece.Direction] {
+        return []
+    }
+    func reachablePositions() -> [Piece.Position] {
+        return []
+    }
+    func getMaximumStep() -> Int {
+        let maximumStep = max(
+            (File.H.rawValue) - self.position.file.rawValue,
+            (Rank.eight.rawValue) - self.position.rank.rawValue,
+            self.position.file.rawValue,
+            self.position.rank.rawValue
+        )
+        
+        return maximumStep
+    }
 }
 
 enum Piece {
@@ -26,6 +49,43 @@ enum Piece {
     enum Color {
         case white
         case black
+    }
+    
+    enum MoveType {
+        case line
+        case dot
+    }
+    
+    enum Direction {
+        case top
+        case topRight
+        case right
+        case rightBottom
+        case bottom
+        case bottomLeft
+        case left
+        case leftTop
+        
+        func getRawValue() -> (file: Int, rank: Int) {
+            switch self {
+            case .top:
+                return (1, 0)
+            case .topRight:
+                return (1, 1)
+            case .right:
+                return (0, 1)
+            case .rightBottom:
+                return (-1, 1)
+            case .bottom:
+                return (-1, 0)
+            case .bottomLeft:
+                return (-1, -1)
+            case .left:
+                return (0, -1)
+            case .leftTop:
+                return (1, -1)
+            }
+        }
     }
 }
 

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -50,6 +50,6 @@ enum File: Int, CaseIterable {
     case A = 0, B, C, D, E, F, G, H
 }
 
-enum Rank: Int {
+enum Rank: Int, CaseIterable {
     case one = 0, two, three, four, five, six, seven, eight
 }

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -27,8 +27,8 @@ class Piece {
     }
     
     struct Position {
-        var rank: Int
-        var file: Int
+        var rank: Rank
+        var file: File
     }
     
     enum Color {
@@ -44,4 +44,12 @@ class Piece {
             }
         }
     }
+}
+
+enum File: Int, CaseIterable {
+    case A = 0, B, C, D, E, F, G, H
+}
+
+enum Rank: Int {
+    case one = 0, two, three, four, five, six, seven, eight
 }

--- a/ray-chess/ray-chess/Chess/Piece.swift
+++ b/ray-chess/ray-chess/Chess/Piece.swift
@@ -8,41 +8,40 @@
 import Foundation
 
 class Piece {
-    var position: PiecePosition
-    var color: PieceColor
+    var position: Piece.Position
+    var color: Piece.Color
     var name: String
     
-    init(color: PieceColor, position: PiecePosition, name: String) {
+    init(color: Piece.Color, position: Piece.Position, name: String) {
         self.color = color
         self.position = position
         self.name = name
     }
     
-    func getColor() -> PieceColor {
+    func getColor() -> Piece.Color {
         return self.color
     }
     
-    func getPosition() -> PiecePosition {
+    func getPosition() -> Piece.Position {
         return self.position
     }
-}
-
-
-struct PiecePosition {
-    var rank: Int
-    var file: Int
-}
-
-enum PieceColor {
-    case white
-    case black
     
-    func getSymbolString() -> String {
-        switch self {
-        case .white:
-            return "9"
-        case .black:
-            return "F"
+    struct Position {
+        var rank: Int
+        var file: Int
+    }
+    
+    enum Color {
+        case white
+        case black
+        
+        func getSymbolString() -> String {
+            switch self {
+            case .white:
+                return "9"
+            case .black:
+                return "F"
+            }
         }
     }
 }

--- a/ray-chess/ray-chess/Chess/Queen.swift
+++ b/ray-chess/ray-chess/Chess/Queen.swift
@@ -1,0 +1,52 @@
+//
+//  Queen.swift
+//  ray-chess
+//
+//  Created by 김상진 on 2022/10/03.
+//
+
+import Foundation
+
+class Queen: Piecable {
+    var position: Piece.Position
+    var color: Piece.Color
+    var name: String
+    var maxCount: Int = 1
+    var moveType: Piece.MoveType = .line
+    
+    init(color: Piece.Color, position: Piece.Position) {
+        self.color = color
+        self.position = position
+        
+        switch color {
+        case .white:
+            self.name = "U+2655"
+        case .black:
+            self.name = "U+265B"
+        }
+    }
+    
+    func initializablePositions() -> [Piece.Position] {
+        switch color {
+        case .black:
+            return [Piece.Position(rank: .one, file: .E)]
+        case .white:
+            return [Piece.Position(rank: .eight, file: .E)]
+        }
+    }
+    
+    func reachableDirections() -> [Piece.Direction] {
+        return Piece.Direction.allCases
+    }
+    
+    func getSymbol() -> String {
+        switch color {
+        case .white:
+            return "♖"
+        case .black:
+            return "♛"
+        }
+    }
+    
+    
+}

--- a/ray-chess/ray-chess/Chess/Rock.swift
+++ b/ray-chess/ray-chess/Chess/Rock.swift
@@ -1,0 +1,65 @@
+//
+//  Rock.swift
+//  ray-chess
+//
+//  Created by 김상진 on 2022/10/03.
+//
+
+import Foundation
+
+class Rook: Piecable {
+    var position: Piece.Position
+    var color: Piece.Color
+    var name: String
+    var maxCount: Int = 2
+    
+    init(color: Piece.Color, position: Piece.Position) {
+        self.color = color
+        self.position = position
+        self.maxCount = 8
+
+        switch color {
+        case .white:
+            self.name = "U+2656"
+        case .black:
+            self.name = "U+265C"
+        }
+    }
+    
+    func reachablePositions() -> [Piece.Position] {
+        var positions = [Piece.Position]()
+        
+        File.allCases.forEach { file in
+            if file != position.file {
+                positions.append(Piece.Position(rank: position.rank, file: file))
+            }
+        }
+        Rank.allCases.forEach { rank in
+            if rank != position.rank {
+                positions.append(Piece.Position(rank: rank, file: position.file))
+            }
+        }
+        
+        return positions
+    }
+    
+    func initializablePositions() -> [Piece.Position] {
+        switch color {
+        case .white:
+            return [Piece.Position(rank: .one, file: .A), Piece.Position(rank: .one, file: .H)]
+        case .black:
+            return [Piece.Position(rank: .eight, file: .A), Piece.Position(rank: .eight, file: .H)]
+        }
+    }
+    
+    func getSymbol() -> String {
+        switch color {
+        case .white:
+            return "♖"
+        case .black:
+            return "♜"
+        }
+    }
+    
+    
+}

--- a/ray-chess/ray-chess/Chess/Rock.swift
+++ b/ray-chess/ray-chess/Chess/Rock.swift
@@ -45,9 +45,9 @@ class Rook: Piecable {
     
     func initializablePositions() -> [Piece.Position] {
         switch color {
-        case .white:
-            return [Piece.Position(rank: .one, file: .A), Piece.Position(rank: .one, file: .H)]
         case .black:
+            return [Piece.Position(rank: .one, file: .A), Piece.Position(rank: .one, file: .H)]
+        case .white:
             return [Piece.Position(rank: .eight, file: .A), Piece.Position(rank: .eight, file: .H)]
         }
     }

--- a/ray-chess/ray-chess/Chess/Rook.swift
+++ b/ray-chess/ray-chess/Chess/Rook.swift
@@ -12,6 +12,7 @@ class Rook: Piecable {
     var color: Piece.Color
     var name: String
     var maxCount: Int = 2
+    var moveType: Piece.MoveType = .line
     
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color
@@ -26,22 +27,26 @@ class Rook: Piecable {
         }
     }
     
-    func reachablePositions() -> [Piece.Position] {
-        var positions = [Piece.Position]()
-        
-        File.allCases.forEach { file in
-            if file != position.file {
-                positions.append(Piece.Position(rank: position.rank, file: file))
-            }
-        }
-        Rank.allCases.forEach { rank in
-            if rank != position.rank {
-                positions.append(Piece.Position(rank: rank, file: position.file))
-            }
-        }
-        
-        return positions
+    func reachableDirections() -> [Piece.Direction] {
+        return [.top, .bottom, .left, .right]
     }
+    
+//    func reachablePositions() -> [Piece.Position] {
+//        var positions = [Piece.Position]()
+//
+//        File.allCases.forEach { file in
+//            if file != position.file {
+//                positions.append(Piece.Position(rank: position.rank, file: file))
+//            }
+//        }
+//        Rank.allCases.forEach { rank in
+//            if rank != position.rank {
+//                positions.append(Piece.Position(rank: rank, file: position.file))
+//            }
+//        }
+//
+//        return positions
+//    }
     
     func initializablePositions() -> [Piece.Position] {
         switch color {

--- a/ray-chess/ray-chess/Chess/Rook.swift
+++ b/ray-chess/ray-chess/Chess/Rook.swift
@@ -17,7 +17,6 @@ class Rook: Piecable {
     init(color: Piece.Color, position: Piece.Position) {
         self.color = color
         self.position = position
-        self.maxCount = 8
 
         switch color {
         case .white:

--- a/ray-chess/ray-chess/Resource/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ray-chess/ray-chess/Resource/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -72,6 +72,11 @@
     },
     {
       "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
       "scale" : "2x",
       "size" : "76x76"
     },

--- a/ray-chess/ray-chessTests/BishopTest.swift
+++ b/ray-chess/ray-chessTests/BishopTest.swift
@@ -13,38 +13,34 @@ class BishopTest: XCTestCase {
     override func setUpWithError() throws {}
 
     override func tearDownWithError() throws {}
-
-    func testExample() throws {
-        testReachablePostion()
-    }
     
-    func testReachablePostion() {
-        let bishop = Bishop(color: .white, position: Piece.Position(rank: .five, file: .D))
-        
-        var result = bishop.reachablePositions()
-        var expectedResult = [
-            Piece.Position(rank: .eight, file: .A),
-            Piece.Position(rank: .two, file: .A),
-            Piece.Position(rank: .seven, file: .B),
-            Piece.Position(rank: .three, file: .B),
-            Piece.Position(rank: .six, file: .C),
-            Piece.Position(rank: .four, file: .C),
-            Piece.Position(rank: .six, file: .E),
-            Piece.Position(rank: .four, file: .E),
-            Piece.Position(rank: .seven, file: .F),
-            Piece.Position(rank: .three, file: .F),
-            Piece.Position(rank: .eight, file: .G),
-            Piece.Position(rank: .two, file: .G),
-            Piece.Position(rank: .one, file: .H)
-        ]
-        
-        result.sort { lhs, rhs in
-            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
-        }
-        expectedResult.sort { lhs, rhs in
-            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
-        }
-        
-        XCTAssertEqual(result, expectedResult)
-    }
+//    func testReachablePostion() {
+//        let bishop = Bishop(color: .white, position: Piece.Position(rank: .five, file: .D))
+//        
+//        var result = bishop.reachablePositions()
+//        var expectedResult = [
+//            Piece.Position(rank: .eight, file: .A),
+//            Piece.Position(rank: .two, file: .A),
+//            Piece.Position(rank: .seven, file: .B),
+//            Piece.Position(rank: .three, file: .B),
+//            Piece.Position(rank: .six, file: .C),
+//            Piece.Position(rank: .four, file: .C),
+//            Piece.Position(rank: .six, file: .E),
+//            Piece.Position(rank: .four, file: .E),
+//            Piece.Position(rank: .seven, file: .F),
+//            Piece.Position(rank: .three, file: .F),
+//            Piece.Position(rank: .eight, file: .G),
+//            Piece.Position(rank: .two, file: .G),
+//            Piece.Position(rank: .one, file: .H)
+//        ]
+//        
+//        result.sort { lhs, rhs in
+//            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+//        }
+//        expectedResult.sort { lhs, rhs in
+//            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+//        }
+//        
+//        XCTAssertEqual(result, expectedResult)
+//    }
 }

--- a/ray-chess/ray-chessTests/BishopTest.swift
+++ b/ray-chess/ray-chessTests/BishopTest.swift
@@ -1,0 +1,50 @@
+//
+//  BishopTest.swift
+//  ray-chessTests
+//
+//  Created by 김상진 on 2022/10/03.
+//
+
+import XCTest
+@testable import ray_chess
+
+class BishopTest: XCTestCase {
+
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testExample() throws {
+        testReachablePostion()
+    }
+    
+    func testReachablePostion() {
+        let bishop = Bishop(color: .white, position: Piece.Position(rank: .five, file: .D))
+        
+        var result = bishop.reachablePosition()
+        var expectedResult = [
+            Piece.Position(rank: .eight, file: .A),
+            Piece.Position(rank: .two, file: .A),
+            Piece.Position(rank: .seven, file: .B),
+            Piece.Position(rank: .three, file: .B),
+            Piece.Position(rank: .six, file: .C),
+            Piece.Position(rank: .four, file: .C),
+            Piece.Position(rank: .six, file: .E),
+            Piece.Position(rank: .four, file: .E),
+            Piece.Position(rank: .seven, file: .F),
+            Piece.Position(rank: .three, file: .F),
+            Piece.Position(rank: .eight, file: .G),
+            Piece.Position(rank: .two, file: .G),
+            Piece.Position(rank: .one, file: .H)
+        ]
+        
+        result.sort { lhs, rhs in
+            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+        }
+        expectedResult.sort { lhs, rhs in
+            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+        }
+        
+        XCTAssertEqual(result, expectedResult)
+    }
+}

--- a/ray-chess/ray-chessTests/BishopTest.swift
+++ b/ray-chess/ray-chessTests/BishopTest.swift
@@ -21,7 +21,7 @@ class BishopTest: XCTestCase {
     func testReachablePostion() {
         let bishop = Bishop(color: .white, position: Piece.Position(rank: .five, file: .D))
         
-        var result = bishop.reachablePosition()
+        var result = bishop.reachablePositions()
         var expectedResult = [
             Piece.Position(rank: .eight, file: .A),
             Piece.Position(rank: .two, file: .A),

--- a/ray-chess/ray-chessTests/BoardBasicTest.swift
+++ b/ray-chess/ray-chessTests/BoardBasicTest.swift
@@ -1,0 +1,27 @@
+//
+//  BoardBasicTest.swift
+//  ray-chessTests
+//
+//  Created by 김상진 on 2022/10/02.
+//
+
+import XCTest
+@testable import ray_chess
+
+class BoardBasicTest: XCTestCase {
+
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testExample() throws {
+        testGetScore()
+    }
+    
+    func testGetScore() {
+        let chessGame = ChessGame()
+        let score = chessGame.board.getScore()
+        XCTAssertEqual(score.white, 8)
+        XCTAssertEqual(score.black, 8)
+    }
+}

--- a/ray-chess/ray-chessTests/BoardMovePawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePawnTest.swift
@@ -32,14 +32,14 @@ class BoardMovePawnTest: XCTestCase {
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(firstResult, true)
+        XCTAssertEqual(firstResult, .success(true))
         
         let secondResult = chessGame.board.canMovePawn(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .white
         )
-        XCTAssertEqual(secondResult, false)
+        XCTAssertEqual(secondResult, .failure(.isNotMyPiece))
     }
     
     func checkExistSameColorPiece() {
@@ -50,7 +50,7 @@ class BoardMovePawnTest: XCTestCase {
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(firstResult, true)
+        XCTAssertEqual(firstResult, .success(true))
         
         chessGame.board.movePawn(
             from: Piece.Position(rank: .two, file: .B),
@@ -62,7 +62,7 @@ class BoardMovePawnTest: XCTestCase {
             to: Piece.Position(rank: .seven, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(secondResult, true)
+        XCTAssertEqual(secondResult, .success(true))
     }
     
     func isOneStepFoward() {
@@ -73,13 +73,13 @@ class BoardMovePawnTest: XCTestCase {
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(firstResult, true)
+        XCTAssertEqual(firstResult, .success(true))
         
         let secondResult = chessGame.board.canMovePawn(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .one, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(secondResult, false)
+        XCTAssertEqual(secondResult, .failure(.isNotReachable))
     }
 }

--- a/ray-chess/ray-chessTests/BoardMovePawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePawnTest.swift
@@ -53,9 +53,8 @@ class BoardMovePawnTest: XCTestCase {
         XCTAssertEqual(firstResult, true)
         
         chessGame.board.movePawn(
-            from: Piece.Position(rank: .three, file: .B),
-            to: Piece.Position(rank: .six, file: .B),
-            pieceName: PawnConst.blackName
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .six, file: .B)
         )
         
         let secondResult = chessGame.board.canMovePawn(

--- a/ray-chess/ray-chessTests/BoardMovePawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePawnTest.swift
@@ -27,14 +27,14 @@ class BoardMovePawnTest: XCTestCase {
     func checkIsMyPiece() {
         let chessGame = ChessGame()
         
-        let firstResult = chessGame.board.canMovePawn(
+        let firstResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, .success(true))
         
-        let secondResult = chessGame.board.canMovePawn(
+        let secondResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .white
@@ -45,7 +45,7 @@ class BoardMovePawnTest: XCTestCase {
     func checkExistSameColorPiece() {
         let chessGame = ChessGame()
         
-        let firstResult = chessGame.board.canMovePawn(
+        let firstResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
@@ -57,7 +57,7 @@ class BoardMovePawnTest: XCTestCase {
             to: Piece.Position(rank: .six, file: .B)
         )
         
-        let secondResult = chessGame.board.canMovePawn(
+        let secondResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .six, file: .B),
             to: Piece.Position(rank: .seven, file: .B),
             currentColor: .black
@@ -68,14 +68,14 @@ class BoardMovePawnTest: XCTestCase {
     func isOneStepFoward() {
         let chessGame = ChessGame()
         
-        let firstResult = chessGame.board.canMovePawn(
+        let firstResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, .success(true))
         
-        let secondResult = chessGame.board.canMovePawn(
+        let secondResult = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .one, file: .B),
             currentColor: .black

--- a/ray-chess/ray-chessTests/BoardMovePawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePawnTest.swift
@@ -28,15 +28,15 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 2, file: 2),
-            to: PiecePosition(rank: 3, file: 2),
+            from: Piece.Position(rank: 2, file: 2),
+            to: Piece.Position(rank: 3, file: 2),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         let secondResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 2, file: 2),
-            to: PiecePosition(rank: 3, file: 2),
+            from: Piece.Position(rank: 2, file: 2),
+            to: Piece.Position(rank: 3, file: 2),
             currentColor: .white
         )
         XCTAssertEqual(secondResult, false)
@@ -46,21 +46,21 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 2, file: 2),
-            to: PiecePosition(rank: 3, file: 2),
+            from: Piece.Position(rank: 2, file: 2),
+            to: Piece.Position(rank: 3, file: 2),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         chessGame.board.movePawn(
-            from: PiecePosition(rank: 3, file: 2),
-            to: PiecePosition(rank: 6, file: 2),
+            from: Piece.Position(rank: 3, file: 2),
+            to: Piece.Position(rank: 6, file: 2),
             pieceName: PawnConst.blackName
         )
         
         let secondResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 6, file: 2),
-            to: PiecePosition(rank: 7, file: 2),
+            from: Piece.Position(rank: 6, file: 2),
+            to: Piece.Position(rank: 7, file: 2),
             currentColor: .black
         )
         XCTAssertEqual(secondResult, true)
@@ -70,15 +70,15 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 2, file: 2),
-            to: PiecePosition(rank: 3, file: 2),
+            from: Piece.Position(rank: 2, file: 2),
+            to: Piece.Position(rank: 3, file: 2),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         let secondResult = chessGame.board.canMovePawn(
-            from: PiecePosition(rank: 2, file: 2),
-            to: PiecePosition(rank: 1, file: 2),
+            from: Piece.Position(rank: 2, file: 2),
+            to: Piece.Position(rank: 1, file: 2),
             currentColor: .black
         )
         XCTAssertEqual(secondResult, false)

--- a/ray-chess/ray-chessTests/BoardMovePawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePawnTest.swift
@@ -28,15 +28,15 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 2, file: 2),
-            to: Piece.Position(rank: 3, file: 2),
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         let secondResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 2, file: 2),
-            to: Piece.Position(rank: 3, file: 2),
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .three, file: .B),
             currentColor: .white
         )
         XCTAssertEqual(secondResult, false)
@@ -46,21 +46,21 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 2, file: 2),
-            to: Piece.Position(rank: 3, file: 2),
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         chessGame.board.movePawn(
-            from: Piece.Position(rank: 3, file: 2),
-            to: Piece.Position(rank: 6, file: 2),
+            from: Piece.Position(rank: .three, file: .B),
+            to: Piece.Position(rank: .six, file: .B),
             pieceName: PawnConst.blackName
         )
         
         let secondResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 6, file: 2),
-            to: Piece.Position(rank: 7, file: 2),
+            from: Piece.Position(rank: .six, file: .B),
+            to: Piece.Position(rank: .seven, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(secondResult, true)
@@ -70,15 +70,15 @@ class BoardMovePawnTest: XCTestCase {
         let chessGame = ChessGame()
         
         let firstResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 2, file: 2),
-            to: Piece.Position(rank: 3, file: 2),
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(firstResult, true)
         
         let secondResult = chessGame.board.canMovePawn(
-            from: Piece.Position(rank: 2, file: 2),
-            to: Piece.Position(rank: 1, file: 2),
+            from: Piece.Position(rank: .two, file: .B),
+            to: Piece.Position(rank: .one, file: .B),
             currentColor: .black
         )
         XCTAssertEqual(secondResult, false)

--- a/ray-chess/ray-chessTests/BoardMovePieceTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePieceTest.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import ray_chess
 
-class BoardMovePawnTest: XCTestCase {
+class BoardMovePieceTest: XCTestCase {
 
     override func setUpWithError() throws {}
 

--- a/ray-chess/ray-chessTests/BoardMovePieceTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePieceTest.swift
@@ -97,4 +97,33 @@ class BoardMovePieceTest: XCTestCase {
         XCTAssertEqual(thirdResult, true)
         
     }
+    
+    func testGetReachablePositions() {
+        let chessGame = ChessGame()
+        chessGame.initializeBishop()
+        
+        let bishop = Bishop(color: .white, position: .init(rank: .eight, file: .C))
+        let result = chessGame.board.getReachablePositions(targetPiece: bishop)
+        let expectedResult = [
+            Piece.Position(rank: .seven, file: .B),
+            Piece.Position(rank: .seven, file: .D),
+            Piece.Position(rank: .six, file: .A),
+            Piece.Position(rank: .six, file: .E),
+            Piece.Position(rank: .five, file: .F),
+            Piece.Position(rank: .four, file: .G),
+            Piece.Position(rank: .three, file: .H),
+        ]
+        XCTAssertEqual(result, expectedResult)
+        
+        chessGame.initializePawn()
+        let result2 = chessGame.board.getReachablePositions(targetPiece: bishop)
+        let expectedResult2 = [Piece.Position]()
+        XCTAssertEqual(result2, expectedResult2)
+        
+        chessGame.initializeRook()
+        let rook = Rook(color: .white, position: .init(rank: .eight, file: .A))
+        let result3 = chessGame.board.getReachablePositions(targetPiece: rook)
+        let expectedResult3 = [Piece.Position(rank: .eight, file: .B)]
+        XCTAssertEqual(result3, expectedResult3)
+    }
 }

--- a/ray-chess/ray-chessTests/BoardMovePieceTest.swift
+++ b/ray-chess/ray-chessTests/BoardMovePieceTest.swift
@@ -14,72 +14,87 @@ class BoardMovePieceTest: XCTestCase {
 
     override func tearDownWithError() throws {}
 
-    func testExample() throws {
-        checkCanMovePawn()
-    }
-
-    func checkCanMovePawn() {
-        checkIsMyPiece()
-        checkExistSameColorPiece()
-        isOneStepFoward()
+    func testCanMovePawn() {
+        let chessGame = ChessGame()
+        chessGame.initializePieces()
+        
+        let firstFrom = Piece.Position(rank: .two, file: .B)
+        let firstTo = Piece.Position(rank: .three, file: .B)
+        let firstMove = chessGame.board.canMovePiece(
+            from: firstFrom,
+            to: firstTo,
+            currentColor: .black
+        )
+        XCTAssertEqual(firstMove, .success(true))
+        chessGame.board.movePawn(from: firstFrom, to: firstTo)
+        
+        let secondFrom = Piece.Position(rank: .one, file: .C)
+        let secondTo = Piece.Position(rank: .two, file: .B)
+        let secondMove = chessGame.board.canMovePiece(
+            from: secondFrom,
+            to: secondTo,
+            currentColor: .black
+        )
+        XCTAssertEqual(secondMove, .success(true))
+        chessGame.board.movePawn(from: secondFrom, to: secondTo)
     }
     
-    func checkIsMyPiece() {
+    func testTargetPieceIsEmpty() {
         let chessGame = ChessGame()
+        chessGame.initializePieces()
         
-        let firstResult = chessGame.board.canMovePiece(
+        let failure = chessGame.board.canMovePiece(
+            from: Piece.Position(rank: .four, file: .B),
+            to: Piece.Position(rank: .three, file: .B),
+            currentColor: .black
+        )
+        XCTAssertEqual(failure, .failure(.isEmptySpace))
+        
+        let success = chessGame.board.canMovePiece(
             from: Piece.Position(rank: .two, file: .B),
             to: Piece.Position(rank: .three, file: .B),
             currentColor: .black
         )
-        XCTAssertEqual(firstResult, .success(true))
-        
-        let secondResult = chessGame.board.canMovePiece(
-            from: Piece.Position(rank: .two, file: .B),
-            to: Piece.Position(rank: .three, file: .B),
-            currentColor: .white
-        )
-        XCTAssertEqual(secondResult, .failure(.isNotMyPiece))
+        XCTAssertEqual(success, .success(true))
     }
     
-    func checkExistSameColorPiece() {
+    func testIsMyPiece() {
         let chessGame = ChessGame()
+        chessGame.initializePieces()
         
-        let firstResult = chessGame.board.canMovePiece(
-            from: Piece.Position(rank: .two, file: .B),
-            to: Piece.Position(rank: .three, file: .B),
-            currentColor: .black
-        )
-        XCTAssertEqual(firstResult, .success(true))
-        
-        chessGame.board.movePawn(
-            from: Piece.Position(rank: .two, file: .B),
-            to: Piece.Position(rank: .six, file: .B)
-        )
-        
-        let secondResult = chessGame.board.canMovePiece(
-            from: Piece.Position(rank: .six, file: .B),
-            to: Piece.Position(rank: .seven, file: .B),
-            currentColor: .black
-        )
-        XCTAssertEqual(secondResult, .success(true))
+        let rook = Rook(color: .white, position: .init(rank: .eight, file: .A))
+        let failure = chessGame.board.isMyPiece(targetPiece: rook, currentColor: .black)
+        let success = chessGame.board.isMyPiece(targetPiece: rook, currentColor: .white)
+        XCTAssertEqual(failure, false)
+        XCTAssertEqual(success, true)
     }
     
-    func isOneStepFoward() {
+    func testExistSameColorPiece() {
+        let chessGame = ChessGame()
+        chessGame.initializePieces()
+        
+        let bishop = Bishop(color: .black, position: .init(rank: .one, file: .C))
+        let success = chessGame.board.isBlockedByMyPiece(targetPiece: bishop, to: .init(rank: .two, file: .B))
+        XCTAssertEqual(success, true)
+        
+        let failure = chessGame.board.isBlockedByMyPiece(targetPiece: bishop, to: .init(rank: .three, file: .A))
+        XCTAssertEqual(failure, false)
+    }
+    
+    func testIsReachablePositions() {
         let chessGame = ChessGame()
         
-        let firstResult = chessGame.board.canMovePiece(
-            from: Piece.Position(rank: .two, file: .B),
-            to: Piece.Position(rank: .three, file: .B),
-            currentColor: .black
-        )
-        XCTAssertEqual(firstResult, .success(true))
+        let pawn = Pawn(color: .white, position: .init(rank: .seven, file: .A))
+        let firstResult = chessGame.board.isReachablePosition(targetPiece: pawn, to: .init(rank: .six, file: .A))
+        XCTAssertEqual(firstResult, true)
         
-        let secondResult = chessGame.board.canMovePiece(
-            from: Piece.Position(rank: .two, file: .B),
-            to: Piece.Position(rank: .one, file: .B),
-            currentColor: .black
-        )
-        XCTAssertEqual(secondResult, .failure(.isNotReachable))
+        let bishop = Bishop(color: .white, position: .init(rank: .eight, file: .C))
+        let secondResult = chessGame.board.isReachablePosition(targetPiece: bishop, to: .init(rank: .six, file: .A))
+        XCTAssertEqual(secondResult, true)
+        
+        let rook = Rook(color: .white, position: .init(rank: .eight, file: .H))
+        let thirdResult = chessGame.board.isReachablePosition(targetPiece: rook, to: .init(rank: .four, file: .H))
+        XCTAssertEqual(thirdResult, true)
+        
     }
 }

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -23,7 +23,7 @@ class BoardSetPawnTest: XCTestCase {
     func checkCanSetPawn() {
         checkIsCorrectRank()
         checkIsEmptyPosition()
-        checkIsOverPawnMaxCount()
+//        checkIsOverPawnMaxCount()
     }
     
     func checkGetPiece() {
@@ -36,20 +36,16 @@ class BoardSetPawnTest: XCTestCase {
         }
         
         // 개체 수 테스트
-        XCTAssertEqual(board.getPieceOnBoard(rank: 0, file: 0), nil)
-        XCTAssertEqual(board.getPieceOnBoard(rank: 1, file: 1) != nil, true)
-        XCTAssertEqual(board.getPieceOnBoard(rank: 9, file: 9), nil)
-        XCTAssertEqual(board.getPieceOnBoard(rank: 8, file: 8) != nil, true)
-        XCTAssertEqual(board.getPieceOnBoard(rank: 2, file: 2) != nil, true)
+        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .one, file: .A)) != nil, true)
+        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .eight, file: .H)) != nil, true)
+        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .two, file: .B)) != nil, true)
     }
     
     func checkSetPiece() {
         let board = Board()
-        let zeroPiece = Piece(color: .white, position: Piece.Position(rank: 0, file: 0), name: "")
-        let onePiece = Piece(color: .white, position: Piece.Position(rank: 1, file: 1), name: "")
-        let nPiece = Piece(color: .white, position: Piece.Position(rank: 8, file: 8), name: "")
+        let onePiece = Piece(color: .white, position: Piece.Position(rank: .one, file: .A), name: "")
+        let nPiece = Piece(color: .white, position: Piece.Position(rank: .eight, file: .H), name: "")
         
-        XCTAssertEqual(board.setPieceOnBoard(position: zeroPiece.position, name: zeroPiece.name), false)
         XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, name: onePiece.name), true)
         XCTAssertEqual(board.setPieceOnBoard(position: nPiece.position, name: nPiece.name), true)
         
@@ -58,13 +54,13 @@ class BoardSetPawnTest: XCTestCase {
     func checkIsCorrectRank() {
         let board = Board()
         
-        let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: 4, file: 1))
+        let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .four, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: invalidRankPostionPawn),
             false
         )
         
-        let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
+        let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: validRankPostionPawn),
             true
@@ -74,7 +70,7 @@ class BoardSetPawnTest: XCTestCase {
     func checkIsEmptyPosition() {
         let board = Board()
         
-        let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
+        let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: dummyPawn),
             true
@@ -82,7 +78,7 @@ class BoardSetPawnTest: XCTestCase {
         
         board.setPieceOnBoard(position: dummyPawn.position, name: dummyPawn.name)
         
-        let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
+        let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         
         XCTAssertEqual(
             board.canSetPawn(pawn: noEmptySpacePawn),
@@ -90,23 +86,23 @@ class BoardSetPawnTest: XCTestCase {
         )
     }
     
-    func checkIsOverPawnMaxCount() {
-        let board = Board()
-        
-        for i in 1...9 {
-            let pawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: i))
-            if i > 8 {
-                XCTAssertEqual(
-                    board.canSetPawn(pawn: pawn),
-                    false
-                )
-            } else {
-                XCTAssertEqual(
-                    board.canSetPawn(pawn: pawn),
-                    true
-                )
-            }
-            board.setPieceOnBoard(position: pawn.position, name: pawn.name)
-        }
-    }
+//    func checkIsOverPawnMaxCount() {
+//        let board = Board()
+//
+//        for i in 1...9 {
+//            let pawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: i))
+//            if i > 8 {
+//                XCTAssertEqual(
+//                    board.canSetPawn(pawn: pawn),
+//                    false
+//                )
+//            } else {
+//                XCTAssertEqual(
+//                    board.canSetPawn(pawn: pawn),
+//                    true
+//                )
+//            }
+//            board.setPieceOnBoard(position: pawn.position, name: pawn.name)
+//        }
+//    }
 }

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -46,8 +46,8 @@ class BoardSetPawnTest: XCTestCase {
         let onePiece = Piece(color: .white, position: Piece.Position(rank: .one, file: .A), name: "")
         let nPiece = Piece(color: .white, position: Piece.Position(rank: .eight, file: .H), name: "")
         
-        XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, name: onePiece.name), true)
-        XCTAssertEqual(board.setPieceOnBoard(position: nPiece.position, name: nPiece.name), true)
+        XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, piece: onePiece), true)
+        XCTAssertEqual(board.setPieceOnBoard(position: nPiece.position, piece: nPiece), true)
         
     }
     
@@ -76,7 +76,7 @@ class BoardSetPawnTest: XCTestCase {
             true
         )
         
-        board.setPieceOnBoard(position: dummyPawn.position, name: dummyPawn.name)
+        board.setPieceOnBoard(position: dummyPawn.position, piece: dummyPawn)
         
         let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -35,16 +35,16 @@ class BoardSetPawnTest: XCTestCase {
             XCTAssertEqual(rank.count, 8)
         }
         
-        // 개체 수 테스트
-        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .one, file: .A)) != nil, true)
-        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .eight, file: .H)) != nil, true)
-        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .two, file: .B)) != nil, true)
+//        // 개체 수 테스트
+//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .one, file: .A)) != nil, true)
+//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .eight, file: .H)) != nil, true)
+//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .two, file: .B)) != nil, true)
     }
     
     func checkSetPiece() {
         let board = Board()
-        let onePiece = Piece(color: .white, position: Piece.Position(rank: .one, file: .A), name: "")
-        let nPiece = Piece(color: .white, position: Piece.Position(rank: .eight, file: .H), name: "")
+        let onePiece = Pawn(color: .white, position: Piece.Position(rank: .one, file: .A))
+        let nPiece = Pawn(color: .white, position: Piece.Position(rank: .eight, file: .H))
         
         XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, piece: onePiece), true)
         XCTAssertEqual(board.setPieceOnBoard(position: nPiece.position, piece: nPiece), true)

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -57,13 +57,13 @@ class BoardSetPawnTest: XCTestCase {
         let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .four, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: invalidRankPostionPawn),
-            false
+            .failure(.wrongInitRank)
         )
         
         let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: validRankPostionPawn),
-            true
+            .success(true)
         )
     }
     
@@ -73,7 +73,7 @@ class BoardSetPawnTest: XCTestCase {
         let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
             board.canSetPawn(pawn: dummyPawn),
-            true
+            .success(true)
         )
         
         board.setPieceOnBoard(position: dummyPawn.position, piece: dummyPawn)
@@ -82,7 +82,7 @@ class BoardSetPawnTest: XCTestCase {
         
         XCTAssertEqual(
             board.canSetPawn(pawn: noEmptySpacePawn),
-            false
+            .failure(.isFulledPosition)
         )
     }
     

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -45,9 +45,9 @@ class BoardSetPawnTest: XCTestCase {
     
     func checkSetPiece() {
         let board = Board()
-        let zeroPiece = Piece(color: .white, position: PiecePosition(rank: 0, file: 0), name: "")
-        let onePiece = Piece(color: .white, position: PiecePosition(rank: 1, file: 1), name: "")
-        let nPiece = Piece(color: .white, position: PiecePosition(rank: 8, file: 8), name: "")
+        let zeroPiece = Piece(color: .white, position: Piece.Position(rank: 0, file: 0), name: "")
+        let onePiece = Piece(color: .white, position: Piece.Position(rank: 1, file: 1), name: "")
+        let nPiece = Piece(color: .white, position: Piece.Position(rank: 8, file: 8), name: "")
         
         XCTAssertEqual(board.setPieceOnBoard(position: zeroPiece.position, name: zeroPiece.name), false)
         XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, name: onePiece.name), true)
@@ -58,13 +58,13 @@ class BoardSetPawnTest: XCTestCase {
     func checkIsCorrectRank() {
         let board = Board()
         
-        let invalidRankPostionPawn = Pawn(color: .black, position: PiecePosition(rank: 4, file: 1))
+        let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: 4, file: 1))
         XCTAssertEqual(
             board.canSetPawn(pawn: invalidRankPostionPawn),
             false
         )
         
-        let validRankPostionPawn = Pawn(color: .black, position: PiecePosition(rank: 2, file: 1))
+        let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
         XCTAssertEqual(
             board.canSetPawn(pawn: validRankPostionPawn),
             true
@@ -74,7 +74,7 @@ class BoardSetPawnTest: XCTestCase {
     func checkIsEmptyPosition() {
         let board = Board()
         
-        let dummyPawn = Pawn(color: .black, position: PiecePosition(rank: 2, file: 1))
+        let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
         XCTAssertEqual(
             board.canSetPawn(pawn: dummyPawn),
             true
@@ -82,7 +82,7 @@ class BoardSetPawnTest: XCTestCase {
         
         board.setPieceOnBoard(position: dummyPawn.position, name: dummyPawn.name)
         
-        let noEmptySpacePawn = Pawn(color: .black, position: PiecePosition(rank: 2, file: 1))
+        let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: 1))
         
         XCTAssertEqual(
             board.canSetPawn(pawn: noEmptySpacePawn),
@@ -94,7 +94,7 @@ class BoardSetPawnTest: XCTestCase {
         let board = Board()
         
         for i in 1...9 {
-            let pawn = Pawn(color: .black, position: PiecePosition(rank: 2, file: i))
+            let pawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: i))
             if i > 8 {
                 XCTAssertEqual(
                     board.canSetPawn(pawn: pawn),

--- a/ray-chess/ray-chessTests/BoardSetPawnTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPawnTest.swift
@@ -56,13 +56,13 @@ class BoardSetPawnTest: XCTestCase {
         
         let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .four, file: .A))
         XCTAssertEqual(
-            board.canSetPawn(pawn: invalidRankPostionPawn),
+            board.canSetPiece(piece: invalidRankPostionPawn),
             .failure(.wrongInitRank)
         )
         
         let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
-            board.canSetPawn(pawn: validRankPostionPawn),
+            board.canSetPiece(piece: validRankPostionPawn),
             .success(true)
         )
     }
@@ -72,7 +72,7 @@ class BoardSetPawnTest: XCTestCase {
         
         let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         XCTAssertEqual(
-            board.canSetPawn(pawn: dummyPawn),
+            board.canSetPiece(piece: dummyPawn),
             .success(true)
         )
         
@@ -81,7 +81,7 @@ class BoardSetPawnTest: XCTestCase {
         let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
         
         XCTAssertEqual(
-            board.canSetPawn(pawn: noEmptySpacePawn),
+            board.canSetPiece(piece: noEmptySpacePawn),
             .failure(.isFulledPosition)
         )
     }

--- a/ray-chess/ray-chessTests/BoardSetPieceTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPieceTest.swift
@@ -14,66 +14,24 @@ class BoardSetPieceTest: XCTestCase {
 
     override func tearDownWithError() throws {}
 
-    func testExample() throws {
-        checkGetPiece()
-        checkSetPiece()
-        checkCanSetPawn()
-    }
-
-    func checkCanSetPawn() {
-        checkIsCorrectRank()
-        checkIsEmptyPosition()
-//        checkIsOverPawnMaxCount()
-    }
-    
-    func checkGetPiece() {
+    func testCanSetPawn() {
         let board = Board()
         
-        // 존재성 테스트
-        XCTAssertEqual(board.matrix.count, 8)
-        board.matrix.forEach { rank in
-            XCTAssertEqual(rank.count, 8)
-        }
-    }
-    
-    func checkSetPiece() {
-        let board = Board()
-        let onePiece = Pawn(color: .white, position: Piece.Position(rank: .one, file: .A))
-        let nPiece = Pawn(color: .white, position: Piece.Position(rank: .eight, file: .H))
-        
-        XCTAssertEqual(board.setPieceOnBoard(position: onePiece.position, piece: onePiece), true)
-        XCTAssertEqual(board.setPieceOnBoard(position: nPiece.position, piece: nPiece), true)
-        
-    }
-    
-    func checkIsCorrectRank() {
-        let board = Board()
-        
-        let invalidRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .four, file: .A))
+        let pawn = Pawn(color: .black, position: .init(rank: .four, file: .A))
         XCTAssertEqual(
-            board.canSetPiece(piece: invalidRankPostionPawn),
+            board.canSetPiece(piece: pawn),
             .failure(.wrongInitRank)
         )
         
-        let validRankPostionPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
+        let rook = Rook(color: .black, position: .init(rank: .two, file: .A))
         XCTAssertEqual(
-            board.canSetPiece(piece: validRankPostionPawn),
-            .success(true)
-        )
-    }
-    
-    func checkIsEmptyPosition() {
-        let board = Board()
-        
-        let dummyPawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
-        XCTAssertEqual(
-            board.canSetPiece(piece: dummyPawn),
-            .success(true)
+            board.canSetPiece(piece: rook),
+            .failure(.wrongInitRank)
         )
         
-        board.setPieceOnBoard(position: dummyPawn.position, piece: dummyPawn)
+        board.setPieceOnBoard(position: pawn.position, piece: pawn)
         
-        let noEmptySpacePawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
+        let noEmptySpacePawn = Pawn(color: .black, position: .init(rank: .two, file: .A))
         
         XCTAssertEqual(
             board.canSetPiece(piece: noEmptySpacePawn),
@@ -81,23 +39,59 @@ class BoardSetPieceTest: XCTestCase {
         )
     }
     
-//    func checkIsOverPawnMaxCount() {
-//        let board = Board()
-//
-//        for i in 1...9 {
-//            let pawn = Pawn(color: .black, position: Piece.Position(rank: 2, file: i))
-//            if i > 8 {
-//                XCTAssertEqual(
-//                    board.canSetPawn(pawn: pawn),
-//                    false
-//                )
-//            } else {
-//                XCTAssertEqual(
-//                    board.canSetPawn(pawn: pawn),
-//                    true
-//                )
-//            }
-//            board.setPieceOnBoard(position: pawn.position, name: pawn.name)
-//        }
-//    }
+    func testIsCorrectRank() {
+        let board = Board()
+        
+        let wrongPawn = Pawn(color: .white, position: .init(rank: .eight, file: .B))
+        let correctPawn = Pawn(color: .white, position: .init(rank: .seven, file: .B))
+        XCTAssertEqual(board.isCorrectRankPosition(piece: wrongPawn), false)
+        XCTAssertEqual(board.isCorrectRankPosition(piece: correctPawn), true)
+        
+        let wrongRook = Rook(color: .white, position: .init(rank: .seven, file: .A))
+        let correctRook = Rook(color: .white, position: .init(rank: .eight, file: .A))
+        XCTAssertEqual(board.isCorrectRankPosition(piece: wrongRook), false)
+        XCTAssertEqual(board.isCorrectRankPosition(piece: correctRook), true)
+        
+        let wrongBishop = Bishop(color: .black, position: .init(rank: .eight, file: .C))
+        let correctBishop = Bishop(color: .black, position: .init(rank: .one, file: .C))
+        XCTAssertEqual(board.isCorrectRankPosition(piece: wrongBishop), false)
+        XCTAssertEqual(board.isCorrectRankPosition(piece: correctBishop), true)
+    }
+    
+    func testIsEmptyPosition() {
+        let board = Board()
+
+        let pawn = Pawn(color: .black, position: Piece.Position(rank: .two, file: .A))
+        XCTAssertEqual(
+            board.IsEmptyPosition(position: pawn.position),
+            true
+        )
+        board.setPieceOnBoard(position: pawn.position, piece: pawn)
+        
+        XCTAssertEqual(
+            board.IsEmptyPosition(position: pawn.position),
+            false
+        )
+    }
+    
+    func testIsOverMaxCount() {
+        let chessGame = ChessGame()
+        chessGame.initializePieces()
+        
+        let pawn = Pawn(color: .white, position: .init(rank: .seven, file: .A))
+        XCTAssertEqual(
+            chessGame.board.IsOverPieceMaxCount(piece: pawn),
+            true
+        )
+        let bishop = Bishop(color: .white, position: .init(rank: .seven, file: .A))
+        XCTAssertEqual(
+            chessGame.board.IsOverPieceMaxCount(piece: bishop),
+            true
+        )
+        let rook = Rook(color: .white, position: .init(rank: .seven, file: .A))
+        XCTAssertEqual(
+            chessGame.board.IsOverPieceMaxCount(piece: rook),
+            true
+        )
+    }
 }

--- a/ray-chess/ray-chessTests/BoardSetPieceTest.swift
+++ b/ray-chess/ray-chessTests/BoardSetPieceTest.swift
@@ -8,7 +8,7 @@
 import XCTest
 @testable import ray_chess
 
-class BoardSetPawnTest: XCTestCase {
+class BoardSetPieceTest: XCTestCase {
 
     override func setUpWithError() throws {}
 
@@ -34,11 +34,6 @@ class BoardSetPawnTest: XCTestCase {
         board.matrix.forEach { rank in
             XCTAssertEqual(rank.count, 8)
         }
-        
-//        // 개체 수 테스트
-//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .one, file: .A)) != nil, true)
-//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .eight, file: .H)) != nil, true)
-//        XCTAssertEqual(board.getPieceOnBoard(position: Piece.Position(rank: .two, file: .B)) != nil, true)
     }
     
     func checkSetPiece() {

--- a/ray-chess/ray-chessTests/ChessGameTest.swift
+++ b/ray-chess/ray-chessTests/ChessGameTest.swift
@@ -1,0 +1,23 @@
+////
+////  ChessGameTest.swift
+////  ray-chessTests
+////
+////  Created by 김상진 on 2022/10/03.
+////
+//
+//import XCTest
+//@testable import ray_chess
+//
+//class ChessGameTest: XCTestCase {
+//
+//    override func setUpWithError() throws {}
+//
+//    override func tearDownWithError() throws {}
+//
+//    func testPossibleToMove() throws {
+//        let chessGame = ChessGame()
+//        chessGame.initializePieces()
+//        
+//        chessGame.possibleToMove(position: .init(rank: <#T##Rank#>, file: <#T##File#>))
+//    }
+//}

--- a/ray-chess/ray-chessTests/ChessGameTest.swift
+++ b/ray-chess/ray-chessTests/ChessGameTest.swift
@@ -1,23 +1,38 @@
-////
-////  ChessGameTest.swift
-////  ray-chessTests
-////
-////  Created by 김상진 on 2022/10/03.
-////
 //
-//import XCTest
-//@testable import ray_chess
+//  ChessGameTest.swift
+//  ray-chessTests
 //
-//class ChessGameTest: XCTestCase {
+//  Created by 김상진 on 2022/10/03.
 //
-//    override func setUpWithError() throws {}
-//
-//    override func tearDownWithError() throws {}
-//
-//    func testPossibleToMove() throws {
-//        let chessGame = ChessGame()
-//        chessGame.initializePieces()
-//        
-//        chessGame.possibleToMove(position: .init(rank: <#T##Rank#>, file: <#T##File#>))
-//    }
-//}
+
+import XCTest
+@testable import ray_chess
+
+class ChessGameTest: XCTestCase {
+
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testPossibleToMove() throws {
+        let chessGame = ChessGame()
+        
+        chessGame.initializePawn()
+        let result = chessGame.possibleToMove(position: .init(rank: .seven, file: .A))
+        let expectedResult = [Piece.Position(rank: .six, file: .A)]
+        XCTAssertEqual(result, expectedResult)
+        
+        chessGame.initializeRook()
+        let result2 = chessGame.possibleToMove(position: .init(rank: .eight, file: .A))
+            .sorted { ($0.rank.rawValue, $0.file.rawValue) > ($1.rank.rawValue, $1.file.rawValue) }
+        let expectedResult2 = [
+            Piece.Position(rank: .eight, file: .B),
+            Piece.Position(rank: .eight, file: .C),
+            Piece.Position(rank: .eight, file: .D),
+            Piece.Position(rank: .eight, file: .E),
+            Piece.Position(rank: .eight, file: .F),
+            Piece.Position(rank: .eight, file: .G),
+        ].sorted { ($0.rank.rawValue, $0.file.rawValue) > ($1.rank.rawValue, $1.file.rawValue) }
+        XCTAssertEqual(result2, expectedResult2)
+    }
+}

--- a/ray-chess/ray-chessTests/ChessGameTest.swift
+++ b/ray-chess/ray-chessTests/ChessGameTest.swift
@@ -35,4 +35,25 @@ class ChessGameTest: XCTestCase {
         ].sorted { ($0.rank.rawValue, $0.file.rawValue) > ($1.rank.rawValue, $1.file.rawValue) }
         XCTAssertEqual(result2, expectedResult2)
     }
+    
+    func testPossibleToMoveQueen() {
+        let chessGame = ChessGame()
+        chessGame.initializeQueen()
+        chessGame.initializeBishop()
+        
+        let result = chessGame.possibleToMove(position: .init(rank: .one, file: .E))
+        let successResults = [
+            result.contains(.init(rank: .two, file: .E)),
+            result.contains(.init(rank: .two, file: .F)),
+            result.contains(.init(rank: .two, file: .D)),
+        ].allSatisfy { $0 == true }
+        
+        let failureResults = [
+            result.contains(.init(rank: .one, file: .C)),
+            result.contains(.init(rank: .one, file: .A)),
+        ].allSatisfy { $0 == false }
+        
+        XCTAssertEqual(successResults, true)
+        XCTAssertEqual(failureResults, true)
+    }
 }

--- a/ray-chess/ray-chessTests/ChessGameTest.swift
+++ b/ray-chess/ray-chessTests/ChessGameTest.swift
@@ -56,4 +56,19 @@ class ChessGameTest: XCTestCase {
         XCTAssertEqual(successResults, true)
         XCTAssertEqual(failureResults, true)
     }
+    
+    func testPossibleToMoveKnight() {
+        let chessGame = ChessGame()
+        chessGame.initializeKnight()
+        
+        let result = chessGame.possibleToMove(position: .init(rank: .one, file: .B))
+            .sorted { ($0.rank.rawValue, $0.file.rawValue) > ($1.rank.rawValue, $1.file.rawValue) }
+        let expectedResult = [
+            Piece.Position(rank: .three, file: .C),
+            Piece.Position(rank: .two, file: .D),
+            Piece.Position(rank: .three, file: .A),
+        ].sorted { ($0.rank.rawValue, $0.file.rawValue) > ($1.rank.rawValue, $1.file.rawValue) }
+        
+        XCTAssertEqual(result, expectedResult)
+    }
 }

--- a/ray-chess/ray-chessTests/RookTest.swift
+++ b/ray-chess/ray-chessTests/RookTest.swift
@@ -14,38 +14,34 @@ class RookTest: XCTestCase {
 
     override func tearDownWithError() throws {}
 
-    func testExample() throws {
-        testReachablePositions()
-    }
-    
-    func testReachablePositions() {
-        let bishop = Rook(color: .white, position: Piece.Position(rank: .five, file: .D))
-        
-        var result = bishop.reachablePositions()
-        var expectedResult = [
-            Piece.Position(rank: .five, file: .A),
-            Piece.Position(rank: .five, file: .B),
-            Piece.Position(rank: .five, file: .C),
-            Piece.Position(rank: .five, file: .E),
-            Piece.Position(rank: .five, file: .F),
-            Piece.Position(rank: .five, file: .G),
-            Piece.Position(rank: .five, file: .H),
-            Piece.Position(rank: .one, file: .D),
-            Piece.Position(rank: .two, file: .D),
-            Piece.Position(rank: .three, file: .D),
-            Piece.Position(rank: .four, file: .D),
-            Piece.Position(rank: .six, file: .D),
-            Piece.Position(rank: .seven, file: .D),
-            Piece.Position(rank: .eight, file: .D)
-        ]
-        
-        result.sort { lhs, rhs in
-            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
-        }
-        expectedResult.sort { lhs, rhs in
-            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
-        }
-        
-        XCTAssertEqual(result, expectedResult)
-    }
+//    func testReachablePositions() {
+//        let bishop = Rook(color: .white, position: Piece.Position(rank: .five, file: .D))
+//        
+//        var result = bishop.reachablePositions()
+//        var expectedResult = [
+//            Piece.Position(rank: .five, file: .A),
+//            Piece.Position(rank: .five, file: .B),
+//            Piece.Position(rank: .five, file: .C),
+//            Piece.Position(rank: .five, file: .E),
+//            Piece.Position(rank: .five, file: .F),
+//            Piece.Position(rank: .five, file: .G),
+//            Piece.Position(rank: .five, file: .H),
+//            Piece.Position(rank: .one, file: .D),
+//            Piece.Position(rank: .two, file: .D),
+//            Piece.Position(rank: .three, file: .D),
+//            Piece.Position(rank: .four, file: .D),
+//            Piece.Position(rank: .six, file: .D),
+//            Piece.Position(rank: .seven, file: .D),
+//            Piece.Position(rank: .eight, file: .D)
+//        ]
+//        
+//        result.sort { lhs, rhs in
+//            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+//        }
+//        expectedResult.sort { lhs, rhs in
+//            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+//        }
+//        
+//        XCTAssertEqual(result, expectedResult)
+//    }
 }

--- a/ray-chess/ray-chessTests/RookTest.swift
+++ b/ray-chess/ray-chessTests/RookTest.swift
@@ -1,0 +1,51 @@
+//
+//  RookTest.swift
+//  ray-chessTests
+//
+//  Created by 김상진 on 2022/10/03.
+//
+
+import XCTest
+@testable import ray_chess
+
+class RookTest: XCTestCase {
+
+    override func setUpWithError() throws {}
+
+    override func tearDownWithError() throws {}
+
+    func testExample() throws {
+        testReachablePositions()
+    }
+    
+    func testReachablePositions() {
+        let bishop = Rook(color: .white, position: Piece.Position(rank: .five, file: .D))
+        
+        var result = bishop.reachablePositions()
+        var expectedResult = [
+            Piece.Position(rank: .five, file: .A),
+            Piece.Position(rank: .five, file: .B),
+            Piece.Position(rank: .five, file: .C),
+            Piece.Position(rank: .five, file: .E),
+            Piece.Position(rank: .five, file: .F),
+            Piece.Position(rank: .five, file: .G),
+            Piece.Position(rank: .five, file: .H),
+            Piece.Position(rank: .one, file: .D),
+            Piece.Position(rank: .two, file: .D),
+            Piece.Position(rank: .three, file: .D),
+            Piece.Position(rank: .four, file: .D),
+            Piece.Position(rank: .six, file: .D),
+            Piece.Position(rank: .seven, file: .D),
+            Piece.Position(rank: .eight, file: .D)
+        ]
+        
+        result.sort { lhs, rhs in
+            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+        }
+        expectedResult.sort { lhs, rhs in
+            (lhs.rank.rawValue, lhs.file.rawValue) > (rhs.rank.rawValue, rhs.file.rawValue)
+        }
+        
+        XCTAssertEqual(result, expectedResult)
+    }
+}


### PR DESCRIPTION
### 설계 추가 및 수정 사항

- **Rank, File을 enum으로 만듬**
    - indexOutOfRange 관련 관리 비용을 줄일 수 있음

- **Piece 클래스를 Piecable 프로토콜로 변경**
    - 다른 말이 추가될때 확장성이 더 좋다고 판단

- **Piecable에 initializablePositions, reachablePositions 추가**
    - 위 정보를 piecable에서 가지고 되면 board에서 관리해야되는 부담을 줄일 수 있다고 판단

- **도움말 기능은 ChessGame에 추가**
    - 아래와 같이 역할을 나눴기 때문에 사용자와 상호작용을 담당하는 ChessGame에 도움말 기능을 추가하는 것이 적절하다고 판단
        - Board: 말의 위치 관련 CRUD 작업
        - ChessGame: 사용자와 상호작용

- **선으로 움직이는 말이 있고, 점으로 움직이는 말이 있어 이들을 구분하기 위해 Piecable에 moveType을 추가**

- **같은 색의 말이 가리고 있는 경우를 판단하기 위해 ReachablePositions 처리 로직을 Board에서 담당함**

- **Board에서의 과도한 분기처리를 방지하기 위해서 Piecable에서도 이동 관련된 특성을 가짐**
    - LineType: reachableDirections
    - DotType: reachablePostions

