### PR TITLE
[ChocOZerO] Game, Player 추가 / Board 개선 / Piece 확장

### DIFF
--- a/SwiftChessApp/SwiftChessApp.xcodeproj/project.pbxproj
+++ b/SwiftChessApp/SwiftChessApp.xcodeproj/project.pbxproj
@@ -7,6 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8E68F01128EC7C67007A68B8 /* PieceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01028EC7C67007A68B8 /* PieceTests.swift */; };
+		8E68F01328ED5675007A68B8 /* BoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01228ED5675007A68B8 /* BoardTests.swift */; };
+		8E68F01528ED5B4F007A68B8 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01428ED5B4F007A68B8 /* Game.swift */; };
+		8E68F01628ED5B4F007A68B8 /* Game.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01428ED5B4F007A68B8 /* Game.swift */; };
+		8E68F01828ED7591007A68B8 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01728ED7591007A68B8 /* Player.swift */; };
+		8E68F01928ED7591007A68B8 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01728ED7591007A68B8 /* Player.swift */; };
+		8E68F01B28ED768A007A68B8 /* GameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E68F01A28ED768A007A68B8 /* GameTests.swift */; };
 		8E9308C028E08A8E00F1BF17 /* SwiftChessAppApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9308BF28E08A8E00F1BF17 /* SwiftChessAppApp.swift */; };
 		8E9308C228E08A8E00F1BF17 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E9308C128E08A8E00F1BF17 /* ContentView.swift */; };
 		8E9308C428E08A9200F1BF17 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 8E9308C328E08A9200F1BF17 /* Assets.xcassets */; };
@@ -38,6 +45,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8E68F01028EC7C67007A68B8 /* PieceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PieceTests.swift; sourceTree = "<group>"; };
+		8E68F01228ED5675007A68B8 /* BoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardTests.swift; sourceTree = "<group>"; };
+		8E68F01428ED5B4F007A68B8 /* Game.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Game.swift; sourceTree = "<group>"; };
+		8E68F01728ED7591007A68B8 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
+		8E68F01A28ED768A007A68B8 /* GameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameTests.swift; sourceTree = "<group>"; };
 		8E9308BC28E08A8E00F1BF17 /* SwiftChessApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SwiftChessApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8E9308BF28E08A8E00F1BF17 /* SwiftChessAppApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftChessAppApp.swift; sourceTree = "<group>"; };
 		8E9308C128E08A8E00F1BF17 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -101,7 +113,9 @@
 			isa = PBXGroup;
 			children = (
 				8EFEA8FE28E315B400AFE29A /* Board.swift */,
+				8E68F01428ED5B4F007A68B8 /* Game.swift */,
 				8EFEA90128E3470F00AFE29A /* Piece.swift */,
+				8E68F01728ED7591007A68B8 /* Player.swift */,
 				8E9308BF28E08A8E00F1BF17 /* SwiftChessAppApp.swift */,
 				8E9308C128E08A8E00F1BF17 /* ContentView.swift */,
 				8E9308C328E08A9200F1BF17 /* Assets.xcassets */,
@@ -122,6 +136,9 @@
 			isa = PBXGroup;
 			children = (
 				8E9308D028E08A9300F1BF17 /* SwiftChessAppTests.swift */,
+				8E68F01028EC7C67007A68B8 /* PieceTests.swift */,
+				8E68F01228ED5675007A68B8 /* BoardTests.swift */,
+				8E68F01A28ED768A007A68B8 /* GameTests.swift */,
 			);
 			path = SwiftChessAppTests;
 			sourceTree = "<group>";
@@ -266,8 +283,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				8EFEA90228E3470F00AFE29A /* Piece.swift in Sources */,
+				8E68F01528ED5B4F007A68B8 /* Game.swift in Sources */,
 				8E9308C228E08A8E00F1BF17 /* ContentView.swift in Sources */,
 				8E9308C028E08A8E00F1BF17 /* SwiftChessAppApp.swift in Sources */,
+				8E68F01828ED7591007A68B8 /* Player.swift in Sources */,
 				8EFEA8FF28E315B400AFE29A /* Board.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -276,9 +295,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8E68F01128EC7C67007A68B8 /* PieceTests.swift in Sources */,
+				8E68F01628ED5B4F007A68B8 /* Game.swift in Sources */,
+				8E68F01328ED5675007A68B8 /* BoardTests.swift in Sources */,
 				8EFEA90028E33AAB00AFE29A /* Board.swift in Sources */,
+				8E68F01928ED7591007A68B8 /* Player.swift in Sources */,
 				8E9308D128E08A9300F1BF17 /* SwiftChessAppTests.swift in Sources */,
 				8EFEA90328E3476400AFE29A /* Piece.swift in Sources */,
+				8E68F01B28ED768A007A68B8 /* GameTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SwiftChessApp/SwiftChessApp/Board.swift
+++ b/SwiftChessApp/SwiftChessApp/Board.swift
@@ -7,84 +7,202 @@
 
 import Foundation
 
+protocol BoardPositionable {
+    func availablePositions(from current: Board.Position, on board: [Board.Position: Piece]) -> [Board.Position]
+}
+
 final class Board {
-    typealias Score = (white: Int, black: Int)
-    typealias Position = (File, Rank)
-
-    enum Rank: Int {
-        case one
-        case two
-        case three
-        case four
-        case five
-        case six
-        case seven
-        case eight
+    struct Position: Hashable {
+        let x: File
+        let y: Rank
     }
 
-    enum File: Int {
+    struct Score {
+        let black: Int
+        let white: Int
+    }
+
+    enum Rank: CaseIterable {
+        case one, two, three, four, five, six, seven, eight
+
+        static let minCoordinate: Int = Rank.one.coordinate
+        static let maxCoordinate: Int = Rank.eight.coordinate
+
+        init?(value: String) {
+            switch value {
+            case "1": self = .one
+            case "2": self = .two
+            case "3": self = .three
+            case "4": self = .four
+            case "5": self = .five
+            case "6": self = .six
+            case "7": self = .seven
+            case "8": self = .eight
+            default: return nil
+            }
+        }
+
+        init?(coordinate: Int) {
+            switch coordinate {
+            case 1: self = .one
+            case 2: self = .two
+            case 3: self = .three
+            case 4: self = .four
+            case 5: self = .five
+            case 6: self = .six
+            case 7: self = .seven
+            case 8: self = .eight
+            default: return nil
+            }
+        }
+
+        var coordinate: Int {
+            switch self {
+            case .one: return 1
+            case .two: return 2
+            case .three: return 3
+            case .four: return 4
+            case .five: return 5
+            case .six: return 6
+            case .seven: return 7
+            case .eight: return 8
+            }
+        }
+    }
+
+    enum File: CaseIterable {
         case A, B, C, D, E, F, G, H
+
+        static let minCoordinate: Int = File.A.coordinate
+        static let maxCoordinate: Int = File.H.coordinate
+
+        init?(value: String) {
+            switch value {
+            case "A": self = .A
+            case "B": self = .B
+            case "C": self = .C
+            case "D": self = .D
+            case "E": self = .E
+            case "F": self = .F
+            case "G": self = .G
+            case "H": self = .H
+            default: return nil
+            }
+        }
+
+        init?(coordinate: Int) {
+            switch coordinate {
+            case 1: self = .A
+            case 2: self = .B
+            case 3: self = .C
+            case 4: self = .D
+            case 5: self = .E
+            case 6: self = .F
+            case 7: self = .G
+            case 8: self = .H
+            default: return nil
+            }
+        }
+
+        var coordinate: Int {
+            switch self {
+            case .A: return 1
+            case .B: return 2
+            case .C: return 3
+            case .D: return 4
+            case .E: return 5
+            case .F: return 6
+            case .G: return 7
+            case .H: return 8
+            }
+        }
     }
 
-    private var whiteScore: Int = 0
-    private var blackScore: Int = 0
+    private var board: [Position: Piece] = [:]
 
-    // 8x8
-    private var board: [[Piece?]]
-    init() {
-        board = [
-//            [Piece(color: .black, type: .rook), Piece(color: .black, type: .knight), Piece(color: .black, type: .bishop), Piece(color: .black, type: .queen), Piece(color: .black, type: .bing), Piece(color: .black, type: .bishop), Piece(color: .black, type: .knight), Piece(color: .black, type: .rook)],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-            [Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn), Piece(color: .black, type: .pawn)],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-            [Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn), Piece(color: .white, type: .pawn)],
-//            [Piece(color: .white, type: .rook), Piece(color: .white, type: .knight), Piece(color: .white, type: .bishop), Piece(color: .white, type: .queen), Piece(color: .white, type: .king), Piece(color: .white, type: .bishop), Piece(color: .white, type: .knight), Piece(color: .white, type: .rook)],
-            [nil, nil, nil, nil, nil, nil, nil, nil],
-        ]
-    }
+    func newGame() {
+        board.removeAll()
 
-    func score() -> Score {
-        (white: whiteScore, black: blackScore)
+        board[Position(x: .A, y: .one)] = Rook(color: .black)
+        board[Position(x: .B, y: .one)] = Knight(color: .black)
+        board[Position(x: .C, y: .one)] = Bishop(color: .black)
+//        board[Position(x: .D, y: .one)] = King(color: .black)
+        board[Position(x: .E, y: .one)] = Queen(color: .black)
+        board[Position(x: .F, y: .one)] = Bishop(color: .black)
+        board[Position(x: .G, y: .one)] = Knight(color: .black)
+        board[Position(x: .H, y: .one)] = Rook(color: .black)
+        board[Position(x: .A, y: .two)] = Pawn(color: .black)
+        board[Position(x: .B, y: .two)] = Pawn(color: .black)
+        board[Position(x: .C, y: .two)] = Pawn(color: .black)
+        board[Position(x: .D, y: .two)] = Pawn(color: .black)
+        board[Position(x: .E, y: .two)] = Pawn(color: .black)
+        board[Position(x: .F, y: .two)] = Pawn(color: .black)
+        board[Position(x: .G, y: .two)] = Pawn(color: .black)
+        board[Position(x: .H, y: .two)] = Pawn(color: .black)
+
+        board[Position(x: .A, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .B, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .C, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .D, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .E, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .F, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .G, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .H, y: .seven)] = Pawn(color: .white)
+        board[Position(x: .A, y: .eight)] = Rook(color: .white)
+        board[Position(x: .B, y: .eight)] = Knight(color: .white)
+        board[Position(x: .C, y: .eight)] = Bishop(color: .white)
+//        board[Position(x: .D, y: .eight)] = King(color: .white)
+        board[Position(x: .E, y: .eight)] = Queen(color: .white)
+        board[Position(x: .F, y: .eight)] = Bishop(color: .white)
+        board[Position(x: .G, y: .eight)] = Knight(color: .white)
+        board[Position(x: .H, y: .eight)] = Rook(color: .white)
     }
 
     func display() -> [String] {
         var result: [String] = []
-        for rank in board {
+        for rank in Rank.allCases {
             var rankDisplay: String = ""
-            for piece in rank {
-                rankDisplay += piece?.image ?? "."
+            for file in File.allCases {
+                if let piece = board[.init(x: file, y: rank)] {
+                    rankDisplay += piece.image
+                } else {
+                    rankDisplay += "."
+                }
             }
             result.append(rankDisplay)
         }
         return result
     }
 
+    @discardableResult
     func move(from: Position, to: Position) -> Bool {
-        guard let piece = board[from.1.rawValue][from.0.rawValue] else { return false }
-        let distances = piece.distances()
+        guard let piece = board.removeValue(forKey: from) else { return false }
+        let availablePositions = piece.availablePositions(from: from, on: board)
         var result: Bool = false
-        distances.forEach { (dx, dy) in
-            let newFile = from.0.rawValue + dx
-            let newRank = from.1.rawValue + dy
-            if newFile == to.0.rawValue, newRank == to.1.rawValue {
-                if let target = board[newRank][newFile] {
-                    let score = target.score
-                    if target.color == .white {
-                        whiteScore += score
-                    } else {
-                        blackScore += score
-                    }
-                    board[newRank][newFile] = piece
-                } else {
-                    board[newRank][newFile] = piece
-                    board[from.1.rawValue][from.0.rawValue] = nil
-                }
+        for position in availablePositions {
+            if position == to {
+                board[to] = piece
                 result = true
+                break
             }
         }
         return result
+    }
+
+    func score() -> Score {
+        var black: Int = 0
+        var white: Int = 0
+        for (_, v) in board {
+            if v.color == .black {
+                black += v.value
+            } else {
+                white += v.value
+            }
+        }
+        return Score(black: black, white: white)
+    }
+
+    func pick(_ position: Position) -> Piece? {
+        board[position]
     }
 }

--- a/SwiftChessApp/SwiftChessApp/Game.swift
+++ b/SwiftChessApp/SwiftChessApp/Game.swift
@@ -1,0 +1,47 @@
+//
+//  Game.swift
+//  SwiftChessApp
+//
+//  Created by taehyeon.lee on 2022/10/05.
+//
+
+import Foundation
+
+class Game {
+    let blackPlayer: Player
+    let whitePlayer: Player
+    private(set) var turn: Color = .white
+    private var inputQueue: [String] = []
+
+    init() {
+        let board: Board = .init()
+        board.newGame()
+        blackPlayer = BlackPlayer(board: board)
+        whitePlayer = WhitePlayer(board: board)
+    }
+
+    func input(_ input: String) -> Bool {
+        inputQueue.append(contentsOf: input.components(separatedBy: "->").map { $0.trimmingCharacters(in: .whitespaces) })
+        guard inputQueue.count == 2 else { return false }
+        let pick = inputQueue[0]
+        let target = inputQueue[1]
+        switch turn {
+        case .black:
+            let result = blackPlayer.move(from: pick, to: target)
+            if result {
+                turn = .white
+                return true
+            } else {
+                return false
+            }
+        case .white:
+            let result = whitePlayer.move(from: pick, to: target)
+            if result {
+                turn = .black
+                return true
+            } else {
+                return false
+            }
+        }
+    }
+}

--- a/SwiftChessApp/SwiftChessApp/Piece.swift
+++ b/SwiftChessApp/SwiftChessApp/Piece.swift
@@ -9,147 +9,330 @@ import Foundation
 
 typealias Distance = (dx: Int, dy: Int)
 
-enum Piece {
-    enum Color {
-        case white
-        case black
-    }
-    enum `Type` {
-        case king
-        case queen
-        case bishop
-        case knight
-        case rook
-        case pawn
-    }
+enum Color {
+    case white
+    case black
+}
 
-    case whiteKing
-    case whiteQueen
-    case whiteBishop
-    case whiteKnight
-    case whiteRook
-    case whitePawn
-    case blackKing
-    case blackQueen
-    case blackBishop
-    case blackKnight
-    case blackRook
-    case blackPawn
+protocol Piece: BoardPositionable {
+    var color: Color { get }
+    var image: String { get }
+    var value: Int { get }
+}
 
-    init(color: Color, type: `Type`) {
-        switch (color, type) {
-        case (.white, .king): self = .whiteKing
-        case (.white, .queen): self = .whiteQueen
-        case (.white, .bishop): self = .whiteBishop
-        case (.white, .knight): self = .whiteKnight
-        case (.white, .rook): self = .whiteRook
-        case (.white, .pawn): self = .whitePawn
-        case (.black, .king): self = .blackKing
-        case (.black, .queen): self = .blackQueen
-        case (.black, .bishop): self = .blackBishop
-        case (.black, .knight): self = .blackKnight
-        case (.black, .rook): self = .blackRook
-        case (.black, .pawn): self = .blackPawn
-        }
-    }
 
-    var color: Color {
-        switch self {
-        case .whiteKing: return .white
-        case .whiteQueen: return .white
-        case .whiteBishop: return .white
-        case .whiteKnight: return .white
-        case .whiteRook: return .white
-        case .whitePawn: return .white
-        case .blackKing: return .black
-        case .blackQueen: return .black
-        case .blackBishop: return .black
-        case .blackKnight: return .black
-        case .blackRook: return .black
-        case .blackPawn: return .black
-        }
-    }
-
-    var type: `Type` {
-        switch self {
-        case .whiteKing: return .king
-        case .whiteQueen: return .queen
-        case .whiteBishop: return .bishop
-        case .whiteKnight: return .knight
-        case .whiteRook: return .rook
-        case .whitePawn: return .pawn
-        case .blackKing: return .king
-        case .blackQueen: return .queen
-        case .blackBishop: return .bishop
-        case .blackKnight: return .knight
-        case .blackRook: return .rook
-        case .blackPawn: return .pawn
-        }
-    }
-
+struct Pawn: Piece {
+    let color: Color
+    var value: Int { 1 }
     var image: String {
-        switch self {
-        case .whiteKing: return "♔"
-        case .whiteQueen: return "♕"
-        case .whiteBishop: return "♗"
-        case .whiteKnight: return "♘"
-        case .whiteRook: return "♖"
-        case .whitePawn: return "♙"
-        case .blackKing: return "♚"
-        case .blackQueen: return "♛"
-        case .blackBishop: return "♝"
-        case .blackKnight: return "♞"
-        case .blackRook: return "♜"
-        case .blackPawn: return "♟"
+        switch color {
+        case .black: return "♟"
+        case .white: return "♙"
         }
     }
 
-    var score: Int {
-        switch type {
-        case .king:   return 1
-        case .queen:  return 1
-        case .bishop: return 1
-        case .knight: return 1
-        case .rook:   return 1
-        case .pawn:   return 1
+    func availablePositions(from current: Board.Position, on board: [Board.Position:Piece]) -> [Board.Position] {
+        let y = current.y.coordinate
+        var targets: [Board.Position] = []
+        var newRank: Board.Rank? = nil
+        switch color {
+        case .white:
+            newRank = Board.Rank(coordinate: y - 1)
+        case .black:
+            newRank = Board.Rank(coordinate: y + 1)
+        }
+        guard let newRank = newRank else { return targets }
+        targets.append(.init(x: current.x, y: newRank))
+        return targets
+    }
+}
+
+struct Bishop: Piece {
+    let color: Color
+    var value: Int { 3 }
+    var image: String {
+        switch color {
+        case .black: return "♝"
+        case .white: return "♗"
         }
     }
 
-    func distances() -> [Distance] {
-        switch (color, type) {
-        case (_, .king):
-            return [(0, 1), (0, -1), (-1, 1), (-1, -1), (1, 1), (1, -1), (1, 0), (-1, 0)]
-        case (_, .queen):
-            return [
-                (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7),
-                (0, -1), (0, -2), (0, -3), (0, -4), (0, -5), (0, -6), (0, -7),
-                (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0),
-                (-1, 0), (-2, 0), (-3, 0), (-4, 0), (-5, 0), (-6, 0), (-7, 0),
-                (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
-                (-1, 1), (-2, 2), (-3, 3), (-4, 4), (-5, 5), (-6, 6),
-                (1, -1), (2, -2), (3, -3), (4, -4), (5, -5), (6, -6),
-                (-1, -1), (-2, -2), (-3, -3), (-4, -4), (-5, -5), (-6, -6),
-            ]
-        case (_, .bishop):
-            return [
-                (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6),
-                (-1, 1), (-2, 2), (-3, 3), (-4, 4), (-5, 5), (-6, 6),
-                (1, -1), (2, -2), (3, -3), (4, -4), (5, -5), (6, -6),
-                (-1, -1), (-2, -2), (-3, -3), (-4, -4), (-5, -5), (-6, -6),
-            ]
-        case (_, .knight):
-            return [(2, 1), (2, -1), (1, 2), (1, -2), (-2, 1), (-2, -1), (-1, 2), (-1, -2)]
-        case (_, .rook):
-            return [
-                (0, 1), (0, 2), (0, 3), (0, 4), (0, 5), (0, 6), (0, 7),
-                (0, -1), (0, -2), (0, -3), (0, -4), (0, -5), (0, -6), (0, -7),
-                (1, 0), (2, 0), (3, 0), (4, 0), (5, 0), (6, 0), (7, 0),
-                (-1, 0), (-2, 0), (-3, 0), (-4, 0), (-5, 0), (-6, 0), (-7, 0),
-            ]
-        case (.white, .pawn):
-            return [(0, -1)]
-        case (.black, .pawn):
-            return [(0, 1)]
+    func availablePositions(from current: Board.Position, on board: [Board.Position: Piece]) -> [Board.Position] {
+        let x = current.x.coordinate
+        let y = current.y.coordinate
+        var targets: [Board.Position] = []
+        targets.append(contentsOf: xLoop(from: x, through: Board.File.maxCoordinate, by: 1, y: y, board: board))
+        targets.append(contentsOf: xLoop(from: x, through: Board.File.minCoordinate, by: -1, y: y, board: board))
+        return targets
+    }
+
+    private func xLoop(from: Int, through: Int, by: Int, y: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        var plusGapAvailable: Bool = true
+        var minusGapAvailable: Bool = true
+        for _x in stride(from: from, through: through, by: by) {
+            guard _x != from else { continue }
+            guard let newFile = Board.File(coordinate: _x) else { break }
+            let gap = abs(from - newFile.coordinate)
+            if plusGapAvailable {
+                plusGapAvailable = addTarget(file: newFile, yCoordinate: y + gap, board: board, targets: &targets)
+            }
+            if minusGapAvailable {
+                minusGapAvailable = addTarget(file: newFile, yCoordinate: y - gap, board: board, targets: &targets)
+            }
+        }
+        return targets
+    }
+
+    private func addTarget(file: Board.File, yCoordinate: Int, board: [Board.Position: Piece], targets: inout [Board.Position]) -> Bool {
+        guard let position = availablePosition(file: file, yCoordinate: yCoordinate, board: board) else { return false }
+        targets.append(position)
+        return board[position] == nil
+    }
+
+    private func availablePosition(file: Board.File, yCoordinate: Int, board: [Board.Position: Piece]) -> Board.Position? {
+        guard let rank = Board.Rank(coordinate: yCoordinate) else { return nil }
+        let position = Board.Position(x: file, y: rank)
+        if let piece = board[position] {
+            if piece.color == color {
+                return nil
+            } else {
+                return position
+            }
+        } else {
+            return position
+        }
+    }
+}
+
+struct Knight: Piece {
+    let color: Color
+    var value: Int { 3 }
+    var image: String {
+        switch color {
+        case .black: return "♞"
+        case .white: return "♘"
+        }
+    }
+
+    func availablePositions(from current: Board.Position, on board: [Board.Position: Piece]) -> [Board.Position] {
+        let x = current.x.coordinate
+        let y = current.y.coordinate
+        var targets: [Board.Position] = []
+        targets.append(contentsOf: filebasePositions(x: x, direction: 1, rank: current.y, board: board))
+        targets.append(contentsOf: filebasePositions(x: x, direction: -1, rank: current.y, board: board))
+        targets.append(contentsOf: rankbasePositions(y: y, direction: 1, file: current.x, board: board))
+        targets.append(contentsOf: rankbasePositions(y: y, direction: -1, file: current.x, board: board))
+        return targets
+    }
+
+    private func filebasePositions(x: Int, direction: Int, rank: Board.Rank, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        guard let file = Board.File(coordinate: x + direction) else { return targets }
+        let position = Board.Position(x: file, y: rank)
+        guard
+            board[position] == nil,
+            let newFile = Board.File(coordinate: file.coordinate + direction)
+        else { return targets }
+        if let newPosition = getPosition(file: newFile, yCoordinate: rank.coordinate + 1, board: board) {
+            targets.append(newPosition)
+        }
+        if let newPosition = getPosition(file: newFile, yCoordinate: rank.coordinate - 1, board: board) {
+            targets.append(newPosition)
+        }
+        return targets
+    }
+
+    private func getPosition(file: Board.File, yCoordinate: Int, board: [Board.Position: Piece]) -> Board.Position? {
+        guard let rank = Board.Rank(coordinate: yCoordinate) else { return nil }
+        let position = Board.Position(x: file, y: rank)
+        if let piece = board[position], piece.color == color {
+            return nil
+        } else {
+            return position
+        }
+    }
+
+    private func rankbasePositions(y: Int, direction: Int, file: Board.File, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        guard let rank = Board.Rank(coordinate: y + direction) else { return targets }
+        let position = Board.Position(x: file, y: rank)
+        guard
+            board[position] == nil,
+            let newRank = Board.Rank(coordinate: rank.coordinate + direction)
+        else { return targets }
+        if let newPosition = getPosition(rank: newRank, xCoordinate: file.coordinate + 1, board: board) {
+            targets.append(newPosition)
+        }
+        if let newPosition = getPosition(rank: newRank, xCoordinate: file.coordinate - 1, board: board) {
+            targets.append(newPosition)
+        }
+        return targets
+    }
+
+    private func getPosition(rank: Board.Rank, xCoordinate: Int, board: [Board.Position: Piece]) -> Board.Position? {
+        guard let file = Board.File(coordinate: xCoordinate) else { return nil }
+        let position = Board.Position(x: file, y: rank)
+        if let piece = board[position], piece.color == color {
+            return nil
+        } else {
+            return position
+        }
+    }
+}
+
+struct Rook: Piece {
+    let color: Color
+    var value: Int { 5 }
+    var image: String {
+        switch color {
+        case .black: return "♜"
+        case .white: return "♖"
+        }
+    }
+
+    func availablePositions(from current: Board.Position, on board: [Board.Position: Piece]) -> [Board.Position] {
+        let x = current.x.coordinate
+        let y = current.y.coordinate
+        var targets: [Board.Position] = []
+        targets.append(contentsOf: rankbasePositions(rank: current.y, from: x, throgh: Board.File.maxCoordinate, by: 1, board: board))
+        targets.append(contentsOf: rankbasePositions(rank: current.y, from: x, throgh: Board.File.minCoordinate, by: -1, board: board))
+        targets.append(contentsOf: filebasePositions(file: current.x, from: y, throgh: Board.Rank.maxCoordinate, by: 1, board: board))
+        targets.append(contentsOf: filebasePositions(file: current.x, from: y, throgh: Board.Rank.minCoordinate, by: -1, board: board))
+        return targets
+    }
+
+    private func rankbasePositions(rank: Board.Rank, from: Int, throgh: Int, by: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        for x in stride(from: from, through: throgh, by: by) {
+            guard x != from else { continue }
+            guard let file = Board.File(coordinate: x) else { break }
+            let position = Board.Position(x: file, y: rank)
+            if let piece = board[position] {
+                if piece.color != color {
+                    targets.append(position)
+                }
+                break
+            } else {
+                targets.append(position)
+            }
+        }
+        return targets
+    }
+
+    private func filebasePositions(file: Board.File, from: Int, throgh: Int, by: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        for y in stride(from: from, through: throgh, by: by) {
+            guard y != from else { continue }
+            guard let rank = Board.Rank(coordinate: y) else { break }
+            let position = Board.Position(x: file, y: rank)
+            if let piece = board[position] {
+                if piece.color != color {
+                    targets.append(position)
+                }
+                break
+            } else {
+                targets.append(position)
+            }
+        }
+        return targets
+    }
+}
+
+struct Queen: Piece {
+    let color: Color
+    var value: Int { 9 }
+    var image: String {
+        switch color {
+        case .black: return "♛"
+        case .white: return "♕"
+        }
+    }
+
+    func availablePositions(from current: Board.Position, on board: [Board.Position: Piece]) -> [Board.Position] {
+        let x = current.x.coordinate
+        let y = current.y.coordinate
+        var targets: [Board.Position] = []
+        targets.append(contentsOf: rankbasePositions(rank: current.y, from: x, throgh: Board.File.maxCoordinate, by: 1, board: board))
+        targets.append(contentsOf: rankbasePositions(rank: current.y, from: x, throgh: Board.File.minCoordinate, by: -1, board: board))
+        targets.append(contentsOf: filebasePositions(file: current.x, from: y, throgh: Board.Rank.maxCoordinate, by: 1, board: board))
+        targets.append(contentsOf: filebasePositions(file: current.x, from: y, throgh: Board.Rank.minCoordinate, by: -1, board: board))
+        targets.append(contentsOf: xLoop(from: x, through: Board.File.maxCoordinate, by: 1, y: y, board: board))
+        targets.append(contentsOf: xLoop(from: x, through: Board.File.minCoordinate, by: -1, y: y, board: board))
+        return targets
+    }
+
+    private func rankbasePositions(rank: Board.Rank, from: Int, throgh: Int, by: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        for x in stride(from: from, through: throgh, by: by) {
+            guard x != from else { continue }
+            guard let file = Board.File(coordinate: x) else { break }
+            let position = Board.Position(x: file, y: rank)
+            if let piece = board[position] {
+                if piece.color != color {
+                    targets.append(position)
+                }
+                break
+            } else {
+                targets.append(position)
+            }
+        }
+        return targets
+    }
+
+    private func filebasePositions(file: Board.File, from: Int, throgh: Int, by: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        for y in stride(from: from, through: throgh, by: by) {
+            guard y != from else { continue }
+            guard let rank = Board.Rank(coordinate: y) else { break }
+            let position = Board.Position(x: file, y: rank)
+            if let piece = board[position] {
+                if piece.color != color {
+                    targets.append(position)
+                }
+                break
+            } else {
+                targets.append(position)
+            }
+        }
+        return targets
+    }
+
+    private func xLoop(from: Int, through: Int, by: Int, y: Int, board: [Board.Position: Piece]) -> [Board.Position] {
+        var targets: [Board.Position] = []
+        var plusGapAvailable: Bool = true
+        var minusGapAvailable: Bool = true
+        for _x in stride(from: from, through: through, by: by) {
+            guard _x != from else { continue }
+            guard let newFile = Board.File(coordinate: _x) else { break }
+            let gap = abs(from - newFile.coordinate)
+            if plusGapAvailable {
+                plusGapAvailable = addTarget(file: newFile, yCoordinate: y + gap, board: board, targets: &targets)
+            }
+            if minusGapAvailable {
+                minusGapAvailable = addTarget(file: newFile, yCoordinate: y - gap, board: board, targets: &targets)
+            }
+        }
+        return targets
+    }
+
+    private func addTarget(file: Board.File, yCoordinate: Int, board: [Board.Position: Piece], targets: inout [Board.Position]) -> Bool {
+        guard let position = availablePosition(file: file, yCoordinate: yCoordinate, board: board) else { return false }
+        targets.append(position)
+        return board[position] == nil
+    }
+
+    private func availablePosition(file: Board.File, yCoordinate: Int, board: [Board.Position: Piece]) -> Board.Position? {
+        guard let rank = Board.Rank(coordinate: yCoordinate) else { return nil }
+        let position = Board.Position(x: file, y: rank)
+        if let piece = board[position] {
+            if piece.color == color {
+                return nil
+            } else {
+                return position
+            }
+        } else {
+            return position
         }
     }
 }

--- a/SwiftChessApp/SwiftChessApp/Player.swift
+++ b/SwiftChessApp/SwiftChessApp/Player.swift
@@ -1,0 +1,57 @@
+//
+//  Player.swift
+//  SwiftChessApp
+//
+//  Created by taehyeon.lee on 2022/10/05.
+//
+
+import Foundation
+
+protocol Player {
+    var team: Color { get }
+    var score: Int { get }
+    var board: Board { get }
+    func move(from current: String, to target: String) -> Bool
+}
+extension Player {
+    func move(from current: String, to target: String) -> Bool {
+        guard
+            current.count == 2,
+            target.count == 2
+        else { return false }
+        guard
+            let currentFile = Board.File(value: String(current[current.startIndex])),
+            let currentRank = Board.Rank(value: String(current[current.index(after: current.startIndex)])),
+            let targetFile = Board.File(value: String(target[target.startIndex])),
+            let targetRank = Board.Rank(value: String(target[target.index(after: current.startIndex)]))
+        else {
+            return false
+        }
+        let piecePosition = Board.Position(x: currentFile, y: currentRank)
+        let targetPosition = Board.Position(x: targetFile, y: targetRank)
+        return board.move(from: piecePosition, to: targetPosition)
+    }
+}
+
+class BlackPlayer: Player {
+    let team: Color = .black
+    let board: Board
+    var score: Int {
+        board.score().black
+    }
+
+    init(board: Board) {
+        self.board = board
+    }
+}
+class WhitePlayer: Player {
+    let team: Color = .white
+    let board: Board
+    var score: Int {
+        board.score().white
+    }
+
+    init(board: Board) {
+        self.board = board
+    }
+}

--- a/SwiftChessApp/SwiftChessAppTests/BoardTests.swift
+++ b/SwiftChessApp/SwiftChessAppTests/BoardTests.swift
@@ -1,0 +1,89 @@
+//
+//  BoardTests.swift
+//  SwiftChessAppTests
+//
+//  Created by taehyeon.lee on 2022/10/05.
+//
+
+import XCTest
+
+final class BoardTests: XCTestCase {
+
+    func test_보드_초기배치() throws {
+        let board = Board()
+        board.newGame()
+        XCTAssertEqual(board.display(), [
+            "♜♞♝.♛♝♞♜",
+            "♟♟♟♟♟♟♟♟",
+            "........",
+            "........",
+            "........",
+            "........",
+            "♙♙♙♙♙♙♙♙",
+            "♖♘♗.♕♗♘♖"
+        ])
+    }
+
+    func test_보드_초기배치_점수() throws {
+        let board = Board()
+        board.newGame()
+        let score = board.score()
+        let answer = Board.Score(black: 39, white: 39)
+        XCTAssertEqual(score.white, answer.white)
+        XCTAssertEqual(score.black, answer.black)
+    }
+
+    func test_보드_white폰1칸이동() throws {
+        let board = Board()
+        board.newGame()
+        let hadMoved = board.move(from: .init(x: .G, y: .seven), to: .init(x: .G, y: .six))
+        if hadMoved {
+            XCTAssertEqual(board.display(), [
+                "♜♞♝.♛♝♞♜",
+                "♟♟♟♟♟♟♟♟",
+                "........",
+                "........",
+                "........",
+                "......♙.",
+                "♙♙♙♙♙♙.♙",
+                "♖♘♗.♕♗♘♖"
+            ])
+        } else {
+            XCTAssertEqual(board.display(), [
+                "♜♞♝.♛♝♞♜",
+                "♟♟♟♟♟♟♟♟",
+                "........",
+                "........",
+                "........",
+                "........",
+                "♙♙♙♙♙♙♙♙",
+                "♖♘♗.♕♗♘♖"
+            ])
+        }
+    }
+
+    func test_보드_white폰이_black폰_먹음() throws {
+        let board = Board()
+        board.newGame()
+        board.move(from: .init(x: .G, y: .seven), to: .init(x: .G, y: .six))
+        board.move(from: .init(x: .G, y: .two), to: .init(x: .G, y: .three))
+        board.move(from: .init(x: .G, y: .six), to: .init(x: .G, y: .five))
+        board.move(from: .init(x: .G, y: .three), to: .init(x: .G, y: .four))
+        board.move(from: .init(x: .G, y: .five), to: .init(x: .G, y: .four))
+        XCTAssertEqual(board.display(), [
+            "♜♞♝.♛♝♞♜",
+            "♟♟♟♟♟♟.♟",
+            "........",
+            "......♙.",
+            "........",
+            "........",
+            "♙♙♙♙♙♙.♙",
+            "♖♘♗.♕♗♘♖"
+        ])
+
+        let score = board.score()
+        let answer = Board.Score(black: 38, white: 39)
+        XCTAssertEqual(score.white, answer.white)
+        XCTAssertEqual(score.black, answer.black)
+    }
+}

--- a/SwiftChessApp/SwiftChessAppTests/GameTests.swift
+++ b/SwiftChessApp/SwiftChessAppTests/GameTests.swift
@@ -1,0 +1,24 @@
+//
+//  GameTests.swift
+//  SwiftChessAppTests
+//
+//  Created by taehyeon.lee on 2022/10/05.
+//
+
+import XCTest
+
+final class GameTests: XCTestCase {
+
+    func test_이동_성공() throws {
+        let game = Game()
+        let result = game.input("G7->G6")
+        XCTAssertTrue(result)
+    }
+
+    func test_이동_실패() throws {
+        let game = Game()
+        let result = game.input("G8->G6")
+        XCTAssertFalse(result)
+    }
+
+}

--- a/SwiftChessApp/SwiftChessAppTests/PieceTests.swift
+++ b/SwiftChessApp/SwiftChessAppTests/PieceTests.swift
@@ -1,0 +1,202 @@
+//
+//  PieceTests.swift
+//  SwiftChessAppTests
+//
+//  Created by taehyeon.lee on 2022/10/04.
+//
+
+import XCTest
+
+final class PieceTests: XCTestCase {
+
+    // MARK: - Bishop
+    func test_Bishop_availablePositions_빈보드() {
+        let bishop = Bishop(color: .black)
+        XCTAssertEqual(bishop.availablePositions(from: .init(x: .D, y: .five), on: [:]), [
+            .init(x: .E, y: .six),
+            .init(x: .E, y: .four),
+            .init(x: .F, y: .seven),
+            .init(x: .F, y: .three),
+            .init(x: .G, y: .eight),
+            .init(x: .G, y: .two),
+            .init(x: .H, y: .one),
+            .init(x: .C, y: .six),
+            .init(x: .C, y: .four),
+            .init(x: .B, y: .seven),
+            .init(x: .B, y: .three),
+            .init(x: .A, y: .eight),
+            .init(x: .A, y: .two)
+        ])
+    }
+    func test_Bishop_availablePositions_장애물() {
+        let bishop = Bishop(color: .black)
+        let availablePositions = bishop.availablePositions(from: .init(x: .D, y: .five), on: [
+            .init(x: .F, y: .seven): Pawn(color: .black),
+            .init(x: .G, y: .two): Pawn(color: .black),
+            .init(x: .C, y: .six): Pawn(color: .black),
+            .init(x: .B, y: .three): Pawn(color: .black)
+        ])
+        XCTAssertEqual(availablePositions, [
+            .init(x: .E, y: .six),
+            .init(x: .E, y: .four),
+            .init(x: .F, y: .three),
+            .init(x: .C, y: .four),
+        ])
+    }
+    func test_Bishop_availablePositions_장애물_상대편() {
+        let bishop = Bishop(color: .black)
+        let availablePositions = bishop.availablePositions(from: .init(x: .D, y: .five), on: [
+            .init(x: .F, y: .seven): Pawn(color: .white),
+            .init(x: .G, y: .two): Pawn(color: .white),
+            .init(x: .C, y: .six): Pawn(color: .white),
+            .init(x: .B, y: .three): Pawn(color: .white)
+        ])
+        XCTAssertEqual(availablePositions, [
+            .init(x: .E, y: .six),
+            .init(x: .E, y: .four),
+            .init(x: .F, y: .seven),
+            .init(x: .F, y: .three),
+            .init(x: .G, y: .two),
+            .init(x: .C, y: .six),
+            .init(x: .C, y: .four),
+            .init(x: .B, y: .three)
+        ])
+    }
+
+    // MARK: - Knight
+    func test_Knight_availablePositions_빈보드() {
+        let knight = Knight(color: .black)
+        XCTAssertEqual(knight.availablePositions(from: .init(x: .D, y: .four), on: [:]), [
+            .init(x: .F, y: .five),
+            .init(x: .F, y: .three),
+            .init(x: .B, y: .five),
+            .init(x: .B, y: .three),
+            .init(x: .E, y: .six),
+            .init(x: .C, y: .six),
+            .init(x: .E, y: .two),
+            .init(x: .C, y: .two),
+        ])
+    }
+    func test_Knight_availablePositions_장애물() {
+        let knight = Knight(color: .black)
+        let availablePositions = knight.availablePositions(from: .init(x: .D, y: .four), on: [
+            .init(x: .D, y: .five): Pawn(color: .black),
+            .init(x: .B, y: .three): Pawn(color: .black),
+            .init(x: .E, y: .two): Pawn(color: .white)
+        ])
+        XCTAssertEqual(availablePositions, [
+            .init(x: .F, y: .five),
+            .init(x: .F, y: .three),
+            .init(x: .B, y: .five),
+            .init(x: .E, y: .two),
+            .init(x: .C, y: .two),
+        ])
+    }
+
+    // MARK: - Rook
+    func test_Rook_availablePositions_빈보드() {
+        let rook = Rook(color: .black)
+        XCTAssertEqual(rook.availablePositions(from: .init(x: .D, y: .five), on: [:]), [
+            .init(x: .E, y: .five),
+            .init(x: .F, y: .five),
+            .init(x: .G, y: .five),
+            .init(x: .H, y: .five),
+            .init(x: .C, y: .five),
+            .init(x: .B, y: .five),
+            .init(x: .A, y: .five),
+            .init(x: .D, y: .six),
+            .init(x: .D, y: .seven),
+            .init(x: .D, y: .eight),
+            .init(x: .D, y: .four),
+            .init(x: .D, y: .three),
+            .init(x: .D, y: .two),
+            .init(x: .D, y: .one),
+        ])
+    }
+    func test_Rook_availablePositions_장애물() {
+        let rook = Rook(color: .black)
+        let availablePositions = rook.availablePositions(from: .init(x: .D, y: .five), on: [
+            .init(x: .D, y: .seven): Pawn(color: .black),
+            .init(x: .G, y: .five): Pawn(color: .black),
+            .init(x: .A, y: .five): Pawn(color: .white)
+        ])
+        XCTAssertEqual(availablePositions, [
+            .init(x: .E, y: .five),
+            .init(x: .F, y: .five),
+            .init(x: .C, y: .five),
+            .init(x: .B, y: .five),
+            .init(x: .A, y: .five),
+            .init(x: .D, y: .six),
+            .init(x: .D, y: .four),
+            .init(x: .D, y: .three),
+            .init(x: .D, y: .two),
+            .init(x: .D, y: .one),
+        ])
+    }
+
+    // MARK: - Queen
+    func test_Queen_availablePositions_빈보드() {
+        let queen = Queen(color: .black)
+        XCTAssertEqual(queen.availablePositions(from: .init(x: .D, y: .four), on: [:]), [
+            .init(x: .E, y: .four),
+            .init(x: .F, y: .four),
+            .init(x: .G, y: .four),
+            .init(x: .H, y: .four),
+            .init(x: .C, y: .four),
+            .init(x: .B, y: .four),
+            .init(x: .A, y: .four),
+            .init(x: .D, y: .five),
+            .init(x: .D, y: .six),
+            .init(x: .D, y: .seven),
+            .init(x: .D, y: .eight),
+            .init(x: .D, y: .three),
+            .init(x: .D, y: .two),
+            .init(x: .D, y: .one),
+            .init(x: .E, y: .five),
+            .init(x: .E, y: .three),
+            .init(x: .F, y: .six),
+            .init(x: .F, y: .two),
+            .init(x: .G, y: .seven),
+            .init(x: .G, y: .one),
+            .init(x: .H, y: .eight),
+            .init(x: .C, y: .five),
+            .init(x: .C, y: .three),
+            .init(x: .B, y: .six),
+            .init(x: .B, y: .two),
+            .init(x: .A, y: .seven),
+            .init(x: .A, y: .one),
+        ])
+    }
+    func test_Queen_availablePositions_장애물() {
+        let queen = Queen(color: .black)
+        let availablePositions = queen.availablePositions(from: .init(x: .D, y: .four), on: [
+            .init(x: .G, y: .four): Pawn(color: .black),
+            .init(x: .B, y: .six): Pawn(color: .black),
+            .init(x: .D, y: .two): Pawn(color: .white)
+        ])
+        XCTAssertEqual(availablePositions, [
+            .init(x: .E, y: .four),
+            .init(x: .F, y: .four),
+            .init(x: .C, y: .four),
+            .init(x: .B, y: .four),
+            .init(x: .A, y: .four),
+            .init(x: .D, y: .five),
+            .init(x: .D, y: .six),
+            .init(x: .D, y: .seven),
+            .init(x: .D, y: .eight),
+            .init(x: .D, y: .three),
+            .init(x: .D, y: .two),
+            .init(x: .E, y: .five),
+            .init(x: .E, y: .three),
+            .init(x: .F, y: .six),
+            .init(x: .F, y: .two),
+            .init(x: .G, y: .seven),
+            .init(x: .G, y: .one),
+            .init(x: .H, y: .eight),
+            .init(x: .C, y: .five),
+            .init(x: .C, y: .three),
+            .init(x: .B, y: .two),
+            .init(x: .A, y: .one),
+        ])
+    }
+}

--- a/SwiftChessApp/SwiftChessAppTests/SwiftChessAppTests.swift
+++ b/SwiftChessApp/SwiftChessAppTests/SwiftChessAppTests.swift
@@ -26,55 +26,6 @@ class SwiftChessAppTests: XCTestCase {
         // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
     }
 
-    func test_보드_초기배치() throws {
-        let board = Board()
-        XCTAssertEqual(board.display(), [
-            "........",
-            "♟♟♟♟♟♟♟♟",
-            "........",
-            "........",
-            "........",
-            "........",
-            "♙♙♙♙♙♙♙♙",
-            "........"
-        ])
-    }
-
-    func test_보드_초기배치_점수() throws {
-        let board = Board()
-        let score = board.score()
-        XCTAssertEqual(score.white, 0)
-        XCTAssertEqual(score.black, 0)
-    }
-
-    func test_보드_white폰1칸이동() throws {
-        let board = Board()
-        let hadMoved = board.move(from: (.G, .seven), to: (.G, .six))
-        if hadMoved {
-            XCTAssertEqual(board.display(), [
-                "........",
-                "♟♟♟♟♟♟♟♟",
-                "........",
-                "........",
-                "........",
-                "......♙.",
-                "♙♙♙♙♙♙.♙",
-                "........"
-            ])
-        } else {
-            XCTAssertEqual(board.display(), [
-                "........",
-                "♟♟♟♟♟♟♟♟",
-                "........",
-                "........",
-                "........",
-                "........",
-                "♙♙♙♙♙♙♙♙",
-                "........"
-            ])
-        }
-    }
-
     func testPerformanceExample() throws {
         // This is an example of a performance test case.
         self.measure {


### PR DESCRIPTION
신규
Game의 역할: player에게 턴을 넘겨주며, input string 을 받는다.
Player의 역할: board에서 자신의 말을 이동한다.

개선
Board가 이중배열이 아닌 포지션을 키로 갖는 딕셔너리 형태로 변경되어 위치에 바로 접근이 용이하도록 변경

확장
Piece를 enum 에서 protocol과 struct로 구현하여 각 구체인스턴스에 맞는 액션을 취하도록 수정하고, King을 제외한 Piece들 정의